### PR TITLE
chore(docs): Updated all defined code

### DIFF
--- a/docs/ui/developers/plugins/typescript/client/enumerations/DisplayStatus.md
+++ b/docs/ui/developers/plugins/typescript/client/enumerations/DisplayStatus.md
@@ -4,7 +4,7 @@
 
 # Enumeration: DisplayStatus
 
-Defined in: [src/modules/Router.ts:22](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L22)
+Defined in: [src/modules/Router.ts:22](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L22)
 
 ## Enumeration Members
 

--- a/docs/ui/developers/plugins/typescript/client/enumerations/GamepadButton.md
+++ b/docs/ui/developers/plugins/typescript/client/enumerations/GamepadButton.md
@@ -4,7 +4,7 @@
 
 # Enumeration: GamepadButton
 
-Defined in: [src/components/FooterLegend.ts:3](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L3)
+Defined in: [src/components/FooterLegend.ts:3](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L3)
 
 ## Enumeration Members
 

--- a/docs/ui/developers/plugins/typescript/client/enumerations/NavEntryPositionPreferences.md
+++ b/docs/ui/developers/plugins/typescript/client/enumerations/NavEntryPositionPreferences.md
@@ -4,7 +4,7 @@
 
 # Enumeration: NavEntryPositionPreferences
 
-Defined in: [src/components/FooterLegend.ts:34](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L34)
+Defined in: [src/components/FooterLegend.ts:34](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L34)
 
 ## Enumeration Members
 

--- a/docs/ui/developers/plugins/typescript/client/enumerations/QuickAccessTab.md
+++ b/docs/ui/developers/plugins/typescript/client/enumerations/QuickAccessTab.md
@@ -4,7 +4,7 @@
 
 # Enumeration: QuickAccessTab
 
-Defined in: [src/modules/Router.ts:10](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L10)
+Defined in: [src/modules/Router.ts:10](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L10)
 
 ## Enumeration Members
 

--- a/docs/ui/developers/plugins/typescript/client/enumerations/SideMenu.md
+++ b/docs/ui/developers/plugins/typescript/client/enumerations/SideMenu.md
@@ -4,7 +4,7 @@
 
 # Enumeration: SideMenu
 
-Defined in: [src/modules/Router.ts:4](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L4)
+Defined in: [src/modules/Router.ts:4](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L4)
 
 ## Enumeration Members
 

--- a/docs/ui/developers/plugins/typescript/client/functions/Button.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/Button.md
@@ -12,7 +12,7 @@ component: UI Components
 function Button(props: PropsWithChildren<ButtonProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Button.ts:11](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Button.ts#L11)
+Defined in: [src/components/Button.ts:11](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Button.ts#L11)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/ButtonItem.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/ButtonItem.md
@@ -12,7 +12,7 @@ component: UI Components
 function ButtonItem(props: PropsWithChildren<ButtonItemProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/ButtonItem.ts:14](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ButtonItem.ts#L14)
+Defined in: [src/components/ButtonItem.ts:14](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ButtonItem.ts#L14)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/Carousel.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/Carousel.md
@@ -12,7 +12,7 @@ component: UI Components
 function Carousel(props: PropsWithChildren<CarouselProps & RefAttributes<HTMLDivElement>>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Carousel.ts:24](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Carousel.ts#L24)
+Defined in: [src/components/Carousel.ts:24](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Carousel.ts#L24)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/ColorPickerModal.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/ColorPickerModal.md
@@ -12,7 +12,7 @@ component: UI Components
 function ColorPickerModal(props: PropsWithChildren<ColorPickerModalProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/custom-components/ColorPickerModal.tsx:17](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/custom-components/ColorPickerModal.tsx#L17)
+Defined in: [src/custom-components/ColorPickerModal.tsx:17](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/custom-components/ColorPickerModal.tsx#L17)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/ConfirmModal.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/ConfirmModal.md
@@ -12,7 +12,7 @@ component: UI Components
 function ConfirmModal(props: PropsWithChildren<ConfirmModalProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Modal.tsx:88](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L88)
+Defined in: [src/components/Modal.tsx:88](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L88)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/ControlsList.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/ControlsList.md
@@ -12,7 +12,7 @@ component: UI Components
 function ControlsList(props: PropsWithChildren<ControlsListProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/ControlsList.ts:12](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ControlsList.ts#L12)
+Defined in: [src/components/ControlsList.ts:12](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ControlsList.ts#L12)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/DialogBody.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/DialogBody.md
@@ -12,7 +12,7 @@ component: UI Components
 function DialogBody(props: PropsWithChildren<DialogCommonProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Dialog.ts:83](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L83)
+Defined in: [src/components/Dialog.ts:83](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L83)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/DialogBodyText.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/DialogBodyText.md
@@ -12,7 +12,7 @@ component: UI Components
 function DialogBodyText(props: PropsWithChildren<DialogCommonProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Dialog.ts:81](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L81)
+Defined in: [src/components/Dialog.ts:81](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L81)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/DialogButton.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/DialogButton.md
@@ -12,7 +12,7 @@ component: UI Components
 function DialogButton(props: PropsWithChildren<DialogButtonProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Dialog.ts:104](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L104)
+Defined in: [src/components/Dialog.ts:104](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L104)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/DialogButtonPrimary.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/DialogButtonPrimary.md
@@ -12,7 +12,7 @@ component: UI Components
 function DialogButtonPrimary(props: PropsWithChildren<DialogButtonProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Dialog.ts:90](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L90)
+Defined in: [src/components/Dialog.ts:90](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L90)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/DialogButtonSecondary.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/DialogButtonSecondary.md
@@ -12,7 +12,7 @@ component: UI Components
 function DialogButtonSecondary(props: PropsWithChildren<DialogButtonProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Dialog.ts:94](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L94)
+Defined in: [src/components/Dialog.ts:94](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L94)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/DialogCheckbox.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/DialogCheckbox.md
@@ -12,7 +12,7 @@ component: UI Components
 function DialogCheckbox(props: PropsWithChildren<DialogCheckboxProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/DialogCheckbox.ts:22](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/DialogCheckbox.ts#L22)
+Defined in: [src/components/DialogCheckbox.ts:22](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/DialogCheckbox.ts#L22)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/DialogControlsSection.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/DialogControlsSection.md
@@ -12,7 +12,7 @@ component: UI Components
 function DialogControlsSection(props: PropsWithChildren<DialogCommonProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Dialog.ts:85](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L85)
+Defined in: [src/components/Dialog.ts:85](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L85)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/DialogControlsSectionHeader.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/DialogControlsSectionHeader.md
@@ -12,7 +12,7 @@ component: UI Components
 function DialogControlsSectionHeader(props: PropsWithChildren<DialogCommonProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Dialog.ts:87](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L87)
+Defined in: [src/components/Dialog.ts:87](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L87)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/DialogFooter.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/DialogFooter.md
@@ -12,7 +12,7 @@ component: UI Components
 function DialogFooter(props: PropsWithChildren<DialogCommonProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Dialog.ts:77](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L77)
+Defined in: [src/components/Dialog.ts:77](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L77)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/DialogHeader.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/DialogHeader.md
@@ -12,7 +12,7 @@ component: UI Components
 function DialogHeader(props: PropsWithChildren<DialogCommonProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Dialog.ts:73](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L73)
+Defined in: [src/components/Dialog.ts:73](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L73)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/DialogLabel.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/DialogLabel.md
@@ -12,7 +12,7 @@ component: UI Components
 function DialogLabel(props: PropsWithChildren<DialogCommonProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Dialog.ts:79](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L79)
+Defined in: [src/components/Dialog.ts:79](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L79)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/DialogSubHeader.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/DialogSubHeader.md
@@ -12,7 +12,7 @@ component: UI Components
 function DialogSubHeader(props: PropsWithChildren<DialogCommonProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Dialog.ts:75](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L75)
+Defined in: [src/components/Dialog.ts:75](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L75)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/Dropdown.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/Dropdown.md
@@ -12,7 +12,7 @@ component: UI Components
 function Dropdown(props: PropsWithChildren<DropdownProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Dropdown.ts:43](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L43)
+Defined in: [src/components/Dropdown.ts:43](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L43)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/DropdownItem.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/DropdownItem.md
@@ -12,7 +12,7 @@ component: UI Components
 function DropdownItem(props: PropsWithChildren<DropdownItemProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Dropdown.ts:52](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L52)
+Defined in: [src/components/Dropdown.ts:52](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L52)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/Field.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/Field.md
@@ -12,7 +12,7 @@ component: UI Components
 function Field(props: PropsWithChildren<FieldProps & RefAttributes<HTMLDivElement>>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Field.ts:28](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Field.ts#L28)
+Defined in: [src/components/Field.ts:28](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Field.ts#L28)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/FocusRing.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/FocusRing.md
@@ -12,7 +12,7 @@ component: UI Components
 function FocusRing(props: PropsWithChildren<FocusRingProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/FocusRing.ts:14](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FocusRing.ts#L14)
+Defined in: [src/components/FocusRing.ts:14](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FocusRing.ts#L14)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/Focusable.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/Focusable.md
@@ -12,7 +12,7 @@ component: UI Components
 function Focusable(props: PropsWithChildren<FocusableProps & RefAttributes<HTMLDivElement>>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Focusable.ts:20](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Focusable.ts#L20)
+Defined in: [src/components/Focusable.ts:20](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Focusable.ts#L20)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/Marquee.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/Marquee.md
@@ -12,7 +12,7 @@ component: UI Components
 function Marquee(props: PropsWithChildren<MarqueeProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Marquee.ts:19](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Marquee.ts#L19)
+Defined in: [src/components/Marquee.ts:19](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Marquee.ts#L19)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/Menu.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/Menu.md
@@ -12,7 +12,7 @@ component: UI Components
 function Menu(props: PropsWithChildren<MenuProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Menu.ts:21](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Menu.ts#L21)
+Defined in: [src/components/Menu.ts:21](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Menu.ts#L21)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/MenuItem.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/MenuItem.md
@@ -12,7 +12,7 @@ component: UI Components
 function MenuItem(props: PropsWithChildren<MenuItemProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Menu.ts:51](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Menu.ts#L51)
+Defined in: [src/components/Menu.ts:51](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Menu.ts#L51)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/ModalPosition.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/ModalPosition.md
@@ -8,7 +8,7 @@
 function ModalPosition(props: PropsWithChildren<SimpleModalProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Modal.tsx:122](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L122)
+Defined in: [src/components/Modal.tsx:122](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L122)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/ModalRoot.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/ModalRoot.md
@@ -12,7 +12,7 @@ component: UI Components
 function ModalRoot(props: PropsWithChildren<ModalRootProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Modal.tsx:93](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L93)
+Defined in: [src/components/Modal.tsx:93](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L93)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/PanelSection.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/PanelSection.md
@@ -12,7 +12,7 @@ component: UI Components
 function PanelSection(props: PropsWithChildren<PanelSectionProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Panel.ts:20](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Panel.ts#L20)
+Defined in: [src/components/Panel.ts:20](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Panel.ts#L20)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/PanelSectionRow.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/PanelSectionRow.md
@@ -12,7 +12,7 @@ component: UI Components
 function PanelSectionRow(props: PropsWithChildren<PanelSectionRowProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Panel.ts:26](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Panel.ts#L26)
+Defined in: [src/components/Panel.ts:26](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Panel.ts#L26)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/ProgressBar.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/ProgressBar.md
@@ -12,7 +12,7 @@ component: UI Components
 function ProgressBar(props: PropsWithChildren<ProgressBarProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/ProgressBar.ts:27](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ProgressBar.ts#L27)
+Defined in: [src/components/ProgressBar.ts:27](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ProgressBar.ts#L27)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/ProgressBarItem.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/ProgressBarItem.md
@@ -12,7 +12,7 @@ component: UI Components
 function ProgressBarItem(props: PropsWithChildren<ProgressBarItemProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/ProgressBar.ts:38](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ProgressBar.ts#L38)
+Defined in: [src/components/ProgressBar.ts:38](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ProgressBar.ts#L38)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/ProgressBarWithInfo.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/ProgressBarWithInfo.md
@@ -12,7 +12,7 @@ component: UI Components
 function ProgressBarWithInfo(props: PropsWithChildren<ProgressBarWithInfoProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/ProgressBar.ts:32](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ProgressBar.ts#L32)
+Defined in: [src/components/ProgressBar.ts:32](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ProgressBar.ts#L32)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/ReorderableList.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/ReorderableList.md
@@ -8,7 +8,7 @@
 function ReorderableList<T>(props: ReorderableListProps<T>): Element
 ```
 
-Defined in: [src/custom-components/ReorderableList.tsx:36](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/custom-components/ReorderableList.tsx#L36)
+Defined in: [src/custom-components/ReorderableList.tsx:36](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/custom-components/ReorderableList.tsx#L36)
 
 ## Type Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/ScrollPanel.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/ScrollPanel.md
@@ -14,7 +14,7 @@ function ScrollPanel(props: PropsWithChildren<{
  }>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Scroll.ts:10](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Scroll.ts#L10)
+Defined in: [src/components/Scroll.ts:10](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Scroll.ts#L10)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/ScrollPanelGroup.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/ScrollPanelGroup.md
@@ -14,7 +14,7 @@ function ScrollPanelGroup(props: PropsWithChildren<{
  }>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Scroll.ts:15](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Scroll.ts#L15)
+Defined in: [src/components/Scroll.ts:15](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Scroll.ts#L15)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/SidebarNavigation.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/SidebarNavigation.md
@@ -12,7 +12,7 @@ component: UI Components
 function SidebarNavigation(props: PropsWithChildren<SidebarNavigationProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/SidebarNavigation.ts:30](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SidebarNavigation.ts#L30)
+Defined in: [src/components/SidebarNavigation.ts:30](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SidebarNavigation.ts#L30)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/SimpleModal.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/SimpleModal.md
@@ -12,7 +12,7 @@ component: UI Components
 function SimpleModal(props: PropsWithChildren<SimpleModalProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Modal.tsx:117](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L117)
+Defined in: [src/components/Modal.tsx:117](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L117)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/SliderField.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/SliderField.md
@@ -12,7 +12,7 @@ component: UI Components
 function SliderField(props: PropsWithChildren<SliderFieldProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/SliderField.ts:32](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SliderField.ts#L32)
+Defined in: [src/components/SliderField.ts:32](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SliderField.ts#L32)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/Spinner.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/Spinner.md
@@ -12,7 +12,7 @@ component: UI Components
 function Spinner(props: PropsWithChildren<SVGAttributes<SVGElement>>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Spinner.ts:6](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Spinner.ts#L6)
+Defined in: [src/components/Spinner.ts:6](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Spinner.ts#L6)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/SteamSpinner.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/SteamSpinner.md
@@ -12,7 +12,7 @@ component: UI Components
 function SteamSpinner(props: PropsWithChildren<SVGAttributes<SVGElement> & SteamSpinnerProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/SteamSpinner.ts:11](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SteamSpinner.ts#L11)
+Defined in: [src/components/SteamSpinner.ts:11](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SteamSpinner.ts#L11)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/SuspensefulImage.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/SuspensefulImage.md
@@ -12,7 +12,7 @@ component: UI Components
 function SuspensefulImage(props: PropsWithChildren<SuspensefulImageProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/custom-components/SuspensefulImage.tsx:12](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/custom-components/SuspensefulImage.tsx#L12)
+Defined in: [src/custom-components/SuspensefulImage.tsx:12](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/custom-components/SuspensefulImage.tsx#L12)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/Tabs.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/Tabs.md
@@ -12,7 +12,7 @@ component: UI Components
 function Tabs(props: PropsWithChildren<TabsProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Tabs.tsx:113](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Tabs.tsx#L113)
+Defined in: [src/components/Tabs.tsx:113](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Tabs.tsx#L113)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/TextField.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/TextField.md
@@ -12,7 +12,7 @@ component: UI Components
 function TextField(props: PropsWithChildren<TextFieldProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/TextField.ts:27](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/TextField.ts#L27)
+Defined in: [src/components/TextField.ts:27](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/TextField.ts#L27)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/Toggle.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/Toggle.md
@@ -12,7 +12,7 @@ component: UI Components
 function Toggle(props: PropsWithChildren<ToggleProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/Toggle.ts:13](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Toggle.ts#L13)
+Defined in: [src/components/Toggle.ts:13](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Toggle.ts#L13)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/ToggleField.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/ToggleField.md
@@ -12,7 +12,7 @@ component: UI Components
 function ToggleField(props: PropsWithChildren<ToggleFieldProps>, context?: any): null | ReactElement
 ```
 
-Defined in: [src/components/ToggleField.ts:14](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ToggleField.ts#L14)
+Defined in: [src/components/ToggleField.ts:14](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ToggleField.ts#L14)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/afterPatch.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/afterPatch.md
@@ -12,7 +12,7 @@ function afterPatch(
    options: PatchOptions): Patch
 ```
 
-Defined in: [src/utils/patcher.ts:43](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/patcher.ts#L43)
+Defined in: [src/utils/patcher.ts:43](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/patcher.ts#L43)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/beforePatch.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/beforePatch.md
@@ -12,7 +12,7 @@ function beforePatch(
    options: PatchOptions): Patch
 ```
 
-Defined in: [src/utils/patcher.ts:24](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/patcher.ts#L24)
+Defined in: [src/utils/patcher.ts:24](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/patcher.ts#L24)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/callable.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/callable.md
@@ -12,7 +12,7 @@ component: Core
 function callable<Args, T>(route: string): (...args: Args) => Promise<T>
 ```
 
-Defined in: [src/api/index.ts:91](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/api/index.ts#L91)
+Defined in: [src/api/index.ts:91](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/api/index.ts#L91)
 
 Make reusable IPC call declarations
 

--- a/docs/ui/developers/plugins/typescript/client/functions/createPropListRegex.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/createPropListRegex.md
@@ -8,7 +8,7 @@
 function createPropListRegex(propList: string[], fromStart: boolean): RegExp
 ```
 
-Defined in: [src/utils/react.ts:18](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/react.ts#L18)
+Defined in: [src/utils/react.ts:18](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/react.ts#L18)
 
 Create a Regular Expression to search for a React component that uses certain props in order.
 

--- a/docs/ui/developers/plugins/typescript/client/functions/fakeRenderComponent.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/fakeRenderComponent.md
@@ -8,7 +8,7 @@
 function fakeRenderComponent(fun: Function, customHooks: any): any
 ```
 
-Defined in: [src/utils/react.ts:33](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/react.ts#L33)
+Defined in: [src/utils/react.ts:33](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/react.ts#L33)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/findClass.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/findClass.md
@@ -8,7 +8,7 @@
 function findClass(name: string): string | void
 ```
 
-Defined in: [src/class-mapper.ts:24](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/class-mapper.ts#L24)
+Defined in: [src/class-mapper.ts:24](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/class-mapper.ts#L24)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/findClassModule.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/findClassModule.md
@@ -8,7 +8,7 @@
 function findClassModule(filter: (module: any) => boolean): ClassModule | void
 ```
 
-Defined in: [src/class-mapper.ts:38](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/class-mapper.ts#L38)
+Defined in: [src/class-mapper.ts:38](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/class-mapper.ts#L38)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/findInReactTree.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/findInReactTree.md
@@ -8,7 +8,7 @@
 function findInReactTree(node: any, filter: findInTreeFilter): any
 ```
 
-Defined in: [src/utils/react.ts:137](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/react.ts#L137)
+Defined in: [src/utils/react.ts:137](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/react.ts#L137)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/findInTree.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/findInTree.md
@@ -11,7 +11,7 @@ function findInTree(
    opts: findInTreeOpts): any
 ```
 
-Defined in: [src/utils/react.ts:116](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/react.ts#L116)
+Defined in: [src/utils/react.ts:116](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/react.ts#L116)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/findSP.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/findSP.md
@@ -8,7 +8,7 @@
 function findSP(): Window
 ```
 
-Defined in: [src/utils/index.ts:21](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/index.ts#L21)
+Defined in: [src/utils/index.ts:21](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/index.ts#L21)
 
 Finds the SP window, since it is a render target as of 10-19-2022's beta
 

--- a/docs/ui/developers/plugins/typescript/client/functions/getFocusNavController.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/getFocusNavController.md
@@ -8,7 +8,7 @@
 function getFocusNavController(): any
 ```
 
-Defined in: [src/utils/index.ts:32](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/index.ts#L32)
+Defined in: [src/utils/index.ts:32](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/index.ts#L32)
 
 Gets the correct FocusNavController, as the Feb 22 2023 beta has two for some reason.
 

--- a/docs/ui/developers/plugins/typescript/client/functions/getGamepadNavigationTrees.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/getGamepadNavigationTrees.md
@@ -8,7 +8,7 @@
 function getGamepadNavigationTrees(): any
 ```
 
-Defined in: [src/utils/index.ts:39](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/index.ts#L39)
+Defined in: [src/utils/index.ts:39](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/index.ts#L39)
 
 Gets the gamepad navigation trees as Valve seems to be moving them.
 

--- a/docs/ui/developers/plugins/typescript/client/functions/getReactInstance.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/getReactInstance.md
@@ -8,7 +8,7 @@
 function getReactInstance(o: Node | Element | HTMLElement): any
 ```
 
-Defined in: [src/utils/react.ts:99](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/react.ts#L99)
+Defined in: [src/utils/react.ts:99](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/react.ts#L99)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/getReactRoot.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/getReactRoot.md
@@ -8,7 +8,7 @@
 function getReactRoot(o: Node | Element | HTMLElement): any
 ```
 
-Defined in: [src/utils/react.ts:90](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/react.ts#L90)
+Defined in: [src/utils/react.ts:90](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/react.ts#L90)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/joinClassNames.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/joinClassNames.md
@@ -8,7 +8,7 @@
 function joinClassNames(...classes: string[]): string
 ```
 
-Defined in: [src/utils/index.ts:10](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/index.ts#L10)
+Defined in: [src/utils/index.ts:10](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/index.ts#L10)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/replacePatch.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/replacePatch.md
@@ -12,7 +12,7 @@ function replacePatch(
    options: PatchOptions): Patch
 ```
 
-Defined in: [src/utils/patcher.ts:62](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/patcher.ts#L62)
+Defined in: [src/utils/patcher.ts:62](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/patcher.ts#L62)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/showContextMenu.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/showContextMenu.md
@@ -12,7 +12,7 @@ component: UI Components
 function showContextMenu(children: ReactNode, parent?: EventTarget): void
 ```
 
-Defined in: [src/components/Menu.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Menu.ts#L8)
+Defined in: [src/components/Menu.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Menu.ts#L8)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/showModal.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/showModal.md
@@ -15,7 +15,7 @@ function showModal(
    props?: ShowModalProps): ShowModalResult
 ```
 
-Defined in: [src/components/Modal.tsx:47](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L47)
+Defined in: [src/components/Modal.tsx:47](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L47)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/sleep.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/sleep.md
@@ -8,7 +8,7 @@
 function sleep(ms: number): Promise<unknown>
 ```
 
-Defined in: [src/utils/index.ts:14](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/index.ts#L14)
+Defined in: [src/utils/index.ts:14](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/index.ts#L14)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/unminifyClass.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/unminifyClass.md
@@ -8,7 +8,7 @@
 function unminifyClass(minifiedClass: string): string | void
 ```
 
-Defined in: [src/class-mapper.ts:42](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/class-mapper.ts#L42)
+Defined in: [src/class-mapper.ts:42](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/class-mapper.ts#L42)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/wrapReactClass.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/wrapReactClass.md
@@ -8,7 +8,7 @@
 function wrapReactClass(node: any, prop: any): any
 ```
 
-Defined in: [src/utils/react.ts:78](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/react.ts#L78)
+Defined in: [src/utils/react.ts:78](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/react.ts#L78)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/functions/wrapReactType.md
+++ b/docs/ui/developers/plugins/typescript/client/functions/wrapReactType.md
@@ -8,7 +8,7 @@
 function wrapReactType(node: any, prop: any): any
 ```
 
-Defined in: [src/utils/react.ts:70](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/react.ts#L70)
+Defined in: [src/utils/react.ts:70](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/react.ts#L70)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/AppDetails.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/AppDetails.md
@@ -4,7 +4,7 @@
 
 # Interface: AppDetails
 
-Defined in: [src/globals/SteamClient.ts:232](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L232)
+Defined in: [src/globals/SteamClient.ts:232](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L232)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/globals/SteamClient.ts:232](https://github.com/shdwmtr/plugutil
 achievements: AppAchievements;
 ```
 
-Defined in: [src/globals/SteamClient.ts:233](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L233)
+Defined in: [src/globals/SteamClient.ts:233](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L233)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/globals/SteamClient.ts:233](https://github.com/shdwmtr/plugutil
 bCanMoveInstallFolder: boolean;
 ```
 
-Defined in: [src/globals/SteamClient.ts:234](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L234)
+Defined in: [src/globals/SteamClient.ts:234](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L234)
 
 ***
 
@@ -34,7 +34,7 @@ Defined in: [src/globals/SteamClient.ts:234](https://github.com/shdwmtr/plugutil
 bCloudAvailable: boolean;
 ```
 
-Defined in: [src/globals/SteamClient.ts:235](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L235)
+Defined in: [src/globals/SteamClient.ts:235](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L235)
 
 ***
 
@@ -44,7 +44,7 @@ Defined in: [src/globals/SteamClient.ts:235](https://github.com/shdwmtr/plugutil
 bCloudEnabledForAccount: boolean;
 ```
 
-Defined in: [src/globals/SteamClient.ts:236](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L236)
+Defined in: [src/globals/SteamClient.ts:236](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L236)
 
 ***
 
@@ -54,7 +54,7 @@ Defined in: [src/globals/SteamClient.ts:236](https://github.com/shdwmtr/plugutil
 bCloudEnabledForApp: boolean;
 ```
 
-Defined in: [src/globals/SteamClient.ts:237](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L237)
+Defined in: [src/globals/SteamClient.ts:237](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L237)
 
 ***
 
@@ -64,7 +64,7 @@ Defined in: [src/globals/SteamClient.ts:237](https://github.com/shdwmtr/plugutil
 bCloudSyncOnSuspendAvailable: boolean;
 ```
 
-Defined in: [src/globals/SteamClient.ts:238](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L238)
+Defined in: [src/globals/SteamClient.ts:238](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L238)
 
 ***
 
@@ -74,7 +74,7 @@ Defined in: [src/globals/SteamClient.ts:238](https://github.com/shdwmtr/plugutil
 bCloudSyncOnSuspendEnabled: boolean;
 ```
 
-Defined in: [src/globals/SteamClient.ts:239](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L239)
+Defined in: [src/globals/SteamClient.ts:239](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L239)
 
 ***
 
@@ -84,7 +84,7 @@ Defined in: [src/globals/SteamClient.ts:239](https://github.com/shdwmtr/plugutil
 bCommunityMarketPresence: boolean;
 ```
 
-Defined in: [src/globals/SteamClient.ts:240](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L240)
+Defined in: [src/globals/SteamClient.ts:240](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L240)
 
 ***
 
@@ -94,7 +94,7 @@ Defined in: [src/globals/SteamClient.ts:240](https://github.com/shdwmtr/plugutil
 bEnableAllowDesktopConfiguration: boolean;
 ```
 
-Defined in: [src/globals/SteamClient.ts:241](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L241)
+Defined in: [src/globals/SteamClient.ts:241](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L241)
 
 ***
 
@@ -104,7 +104,7 @@ Defined in: [src/globals/SteamClient.ts:241](https://github.com/shdwmtr/plugutil
 bFreeRemovableLicense: boolean;
 ```
 
-Defined in: [src/globals/SteamClient.ts:242](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L242)
+Defined in: [src/globals/SteamClient.ts:242](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L242)
 
 ***
 
@@ -114,7 +114,7 @@ Defined in: [src/globals/SteamClient.ts:242](https://github.com/shdwmtr/plugutil
 bHasAllLegacyCDKeys: boolean;
 ```
 
-Defined in: [src/globals/SteamClient.ts:243](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L243)
+Defined in: [src/globals/SteamClient.ts:243](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L243)
 
 ***
 
@@ -124,7 +124,7 @@ Defined in: [src/globals/SteamClient.ts:243](https://github.com/shdwmtr/plugutil
 bHasAnyLocalContent: boolean;
 ```
 
-Defined in: [src/globals/SteamClient.ts:244](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L244)
+Defined in: [src/globals/SteamClient.ts:244](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L244)
 
 ***
 
@@ -134,7 +134,7 @@ Defined in: [src/globals/SteamClient.ts:244](https://github.com/shdwmtr/plugutil
 bHasLockedPrivateBetas: boolean;
 ```
 
-Defined in: [src/globals/SteamClient.ts:245](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L245)
+Defined in: [src/globals/SteamClient.ts:245](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L245)
 
 ***
 
@@ -144,7 +144,7 @@ Defined in: [src/globals/SteamClient.ts:245](https://github.com/shdwmtr/plugutil
 bIsExcludedFromSharing: boolean;
 ```
 
-Defined in: [src/globals/SteamClient.ts:246](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L246)
+Defined in: [src/globals/SteamClient.ts:246](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L246)
 
 ***
 
@@ -154,7 +154,7 @@ Defined in: [src/globals/SteamClient.ts:246](https://github.com/shdwmtr/plugutil
 bIsSubscribedTo: boolean;
 ```
 
-Defined in: [src/globals/SteamClient.ts:247](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L247)
+Defined in: [src/globals/SteamClient.ts:247](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L247)
 
 ***
 
@@ -164,7 +164,7 @@ Defined in: [src/globals/SteamClient.ts:247](https://github.com/shdwmtr/plugutil
 bOverlayEnabled: boolean;
 ```
 
-Defined in: [src/globals/SteamClient.ts:248](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L248)
+Defined in: [src/globals/SteamClient.ts:248](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L248)
 
 ***
 
@@ -174,7 +174,7 @@ Defined in: [src/globals/SteamClient.ts:248](https://github.com/shdwmtr/plugutil
 bOverrideInternalResolution: boolean;
 ```
 
-Defined in: [src/globals/SteamClient.ts:249](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L249)
+Defined in: [src/globals/SteamClient.ts:249](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L249)
 
 ***
 
@@ -184,7 +184,7 @@ Defined in: [src/globals/SteamClient.ts:249](https://github.com/shdwmtr/plugutil
 bRequiresLegacyCDKey: boolean;
 ```
 
-Defined in: [src/globals/SteamClient.ts:250](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L250)
+Defined in: [src/globals/SteamClient.ts:250](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L250)
 
 ***
 
@@ -194,7 +194,7 @@ Defined in: [src/globals/SteamClient.ts:250](https://github.com/shdwmtr/plugutil
 bShortcutIsVR: boolean;
 ```
 
-Defined in: [src/globals/SteamClient.ts:251](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L251)
+Defined in: [src/globals/SteamClient.ts:251](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L251)
 
 ***
 
@@ -204,7 +204,7 @@ Defined in: [src/globals/SteamClient.ts:251](https://github.com/shdwmtr/plugutil
 bShowCDKeyInMenus: boolean;
 ```
 
-Defined in: [src/globals/SteamClient.ts:252](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L252)
+Defined in: [src/globals/SteamClient.ts:252](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L252)
 
 ***
 
@@ -214,7 +214,7 @@ Defined in: [src/globals/SteamClient.ts:252](https://github.com/shdwmtr/plugutil
 bShowControllerConfig: boolean;
 ```
 
-Defined in: [src/globals/SteamClient.ts:253](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L253)
+Defined in: [src/globals/SteamClient.ts:253](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L253)
 
 ***
 
@@ -224,7 +224,7 @@ Defined in: [src/globals/SteamClient.ts:253](https://github.com/shdwmtr/plugutil
 bSupportsCDKeyCopyToClipboard: boolean;
 ```
 
-Defined in: [src/globals/SteamClient.ts:254](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L254)
+Defined in: [src/globals/SteamClient.ts:254](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L254)
 
 ***
 
@@ -234,7 +234,7 @@ Defined in: [src/globals/SteamClient.ts:254](https://github.com/shdwmtr/plugutil
 bVRGameTheatreEnabled: boolean;
 ```
 
-Defined in: [src/globals/SteamClient.ts:255](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L255)
+Defined in: [src/globals/SteamClient.ts:255](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L255)
 
 ***
 
@@ -244,7 +244,7 @@ Defined in: [src/globals/SteamClient.ts:255](https://github.com/shdwmtr/plugutil
 bWorkshopVisible: boolean;
 ```
 
-Defined in: [src/globals/SteamClient.ts:256](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L256)
+Defined in: [src/globals/SteamClient.ts:256](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L256)
 
 ***
 
@@ -254,7 +254,7 @@ Defined in: [src/globals/SteamClient.ts:256](https://github.com/shdwmtr/plugutil
 eAppOwnershipFlags: number;
 ```
 
-Defined in: [src/globals/SteamClient.ts:257](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L257)
+Defined in: [src/globals/SteamClient.ts:257](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L257)
 
 ***
 
@@ -264,7 +264,7 @@ Defined in: [src/globals/SteamClient.ts:257](https://github.com/shdwmtr/plugutil
 eAutoUpdateValue: number;
 ```
 
-Defined in: [src/globals/SteamClient.ts:258](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L258)
+Defined in: [src/globals/SteamClient.ts:258](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L258)
 
 ***
 
@@ -274,7 +274,7 @@ Defined in: [src/globals/SteamClient.ts:258](https://github.com/shdwmtr/plugutil
 eBackgroundDownloads: number;
 ```
 
-Defined in: [src/globals/SteamClient.ts:259](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L259)
+Defined in: [src/globals/SteamClient.ts:259](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L259)
 
 ***
 
@@ -284,7 +284,7 @@ Defined in: [src/globals/SteamClient.ts:259](https://github.com/shdwmtr/plugutil
 eCloudSync: number;
 ```
 
-Defined in: [src/globals/SteamClient.ts:260](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L260)
+Defined in: [src/globals/SteamClient.ts:260](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L260)
 
 ***
 
@@ -294,7 +294,7 @@ Defined in: [src/globals/SteamClient.ts:260](https://github.com/shdwmtr/plugutil
 eControllerRumblePreference: number;
 ```
 
-Defined in: [src/globals/SteamClient.ts:261](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L261)
+Defined in: [src/globals/SteamClient.ts:261](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L261)
 
 ***
 
@@ -304,7 +304,7 @@ Defined in: [src/globals/SteamClient.ts:261](https://github.com/shdwmtr/plugutil
 eDisplayStatus: number;
 ```
 
-Defined in: [src/globals/SteamClient.ts:262](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L262)
+Defined in: [src/globals/SteamClient.ts:262](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L262)
 
 ***
 
@@ -314,7 +314,7 @@ Defined in: [src/globals/SteamClient.ts:262](https://github.com/shdwmtr/plugutil
 eEnableThirdPartyControllerConfiguration: number;
 ```
 
-Defined in: [src/globals/SteamClient.ts:263](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L263)
+Defined in: [src/globals/SteamClient.ts:263](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L263)
 
 ***
 
@@ -324,7 +324,7 @@ Defined in: [src/globals/SteamClient.ts:263](https://github.com/shdwmtr/plugutil
 eSteamInputControllerMask: number;
 ```
 
-Defined in: [src/globals/SteamClient.ts:264](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L264)
+Defined in: [src/globals/SteamClient.ts:264](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L264)
 
 ***
 
@@ -334,7 +334,7 @@ Defined in: [src/globals/SteamClient.ts:264](https://github.com/shdwmtr/plugutil
 iInstallFolder: number;
 ```
 
-Defined in: [src/globals/SteamClient.ts:265](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L265)
+Defined in: [src/globals/SteamClient.ts:265](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L265)
 
 ***
 
@@ -344,7 +344,7 @@ Defined in: [src/globals/SteamClient.ts:265](https://github.com/shdwmtr/plugutil
 lDiskUsageBytes: number;
 ```
 
-Defined in: [src/globals/SteamClient.ts:266](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L266)
+Defined in: [src/globals/SteamClient.ts:266](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L266)
 
 ***
 
@@ -354,7 +354,7 @@ Defined in: [src/globals/SteamClient.ts:266](https://github.com/shdwmtr/plugutil
 lDlcUsageBytes: number;
 ```
 
-Defined in: [src/globals/SteamClient.ts:267](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L267)
+Defined in: [src/globals/SteamClient.ts:267](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L267)
 
 ***
 
@@ -366,7 +366,7 @@ optional libraryAssets: {
 };
 ```
 
-Defined in: [src/globals/SteamClient.ts:307](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L307)
+Defined in: [src/globals/SteamClient.ts:307](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L307)
 
 #### logoPosition?
 
@@ -382,7 +382,7 @@ optional logoPosition: LogoPosition;
 nBuildID: number;
 ```
 
-Defined in: [src/globals/SteamClient.ts:268](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L268)
+Defined in: [src/globals/SteamClient.ts:268](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L268)
 
 ***
 
@@ -392,7 +392,7 @@ Defined in: [src/globals/SteamClient.ts:268](https://github.com/shdwmtr/plugutil
 nCompatToolPriority: number;
 ```
 
-Defined in: [src/globals/SteamClient.ts:269](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L269)
+Defined in: [src/globals/SteamClient.ts:269](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L269)
 
 ***
 
@@ -402,7 +402,7 @@ Defined in: [src/globals/SteamClient.ts:269](https://github.com/shdwmtr/plugutil
 nPlaytimeForever: number;
 ```
 
-Defined in: [src/globals/SteamClient.ts:270](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L270)
+Defined in: [src/globals/SteamClient.ts:270](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L270)
 
 ***
 
@@ -412,7 +412,7 @@ Defined in: [src/globals/SteamClient.ts:270](https://github.com/shdwmtr/plugutil
 nScreenshots: number;
 ```
 
-Defined in: [src/globals/SteamClient.ts:271](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L271)
+Defined in: [src/globals/SteamClient.ts:271](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L271)
 
 ***
 
@@ -422,7 +422,7 @@ Defined in: [src/globals/SteamClient.ts:271](https://github.com/shdwmtr/plugutil
 rtLastTimePlayed: number;
 ```
 
-Defined in: [src/globals/SteamClient.ts:272](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L272)
+Defined in: [src/globals/SteamClient.ts:272](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L272)
 
 ***
 
@@ -432,7 +432,7 @@ Defined in: [src/globals/SteamClient.ts:272](https://github.com/shdwmtr/plugutil
 rtLastUpdated: number;
 ```
 
-Defined in: [src/globals/SteamClient.ts:273](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L273)
+Defined in: [src/globals/SteamClient.ts:273](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L273)
 
 ***
 
@@ -442,7 +442,7 @@ Defined in: [src/globals/SteamClient.ts:273](https://github.com/shdwmtr/plugutil
 rtPurchased: number;
 ```
 
-Defined in: [src/globals/SteamClient.ts:274](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L274)
+Defined in: [src/globals/SteamClient.ts:274](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L274)
 
 ***
 
@@ -455,7 +455,7 @@ selectedLanguage: {
 };
 ```
 
-Defined in: [src/globals/SteamClient.ts:275](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L275)
+Defined in: [src/globals/SteamClient.ts:275](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L275)
 
 #### strDisplayName
 
@@ -477,7 +477,7 @@ strShortName: string;
 strCloudBytesAvailable: string;
 ```
 
-Defined in: [src/globals/SteamClient.ts:279](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L279)
+Defined in: [src/globals/SteamClient.ts:279](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L279)
 
 ***
 
@@ -487,7 +487,7 @@ Defined in: [src/globals/SteamClient.ts:279](https://github.com/shdwmtr/plugutil
 strCloudBytesUsed: string;
 ```
 
-Defined in: [src/globals/SteamClient.ts:280](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L280)
+Defined in: [src/globals/SteamClient.ts:280](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L280)
 
 ***
 
@@ -497,7 +497,7 @@ Defined in: [src/globals/SteamClient.ts:280](https://github.com/shdwmtr/plugutil
 strCompatToolDisplayName: string;
 ```
 
-Defined in: [src/globals/SteamClient.ts:281](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L281)
+Defined in: [src/globals/SteamClient.ts:281](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L281)
 
 ***
 
@@ -507,7 +507,7 @@ Defined in: [src/globals/SteamClient.ts:281](https://github.com/shdwmtr/plugutil
 strCompatToolName: string;
 ```
 
-Defined in: [src/globals/SteamClient.ts:282](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L282)
+Defined in: [src/globals/SteamClient.ts:282](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L282)
 
 ***
 
@@ -517,7 +517,7 @@ Defined in: [src/globals/SteamClient.ts:282](https://github.com/shdwmtr/plugutil
 strDeveloperName: string;
 ```
 
-Defined in: [src/globals/SteamClient.ts:283](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L283)
+Defined in: [src/globals/SteamClient.ts:283](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L283)
 
 ***
 
@@ -527,7 +527,7 @@ Defined in: [src/globals/SteamClient.ts:283](https://github.com/shdwmtr/plugutil
 strDeveloperURL: string;
 ```
 
-Defined in: [src/globals/SteamClient.ts:284](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L284)
+Defined in: [src/globals/SteamClient.ts:284](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L284)
 
 ***
 
@@ -537,7 +537,7 @@ Defined in: [src/globals/SteamClient.ts:284](https://github.com/shdwmtr/plugutil
 strDisplayName: string;
 ```
 
-Defined in: [src/globals/SteamClient.ts:285](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L285)
+Defined in: [src/globals/SteamClient.ts:285](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L285)
 
 ***
 
@@ -547,7 +547,7 @@ Defined in: [src/globals/SteamClient.ts:285](https://github.com/shdwmtr/plugutil
 strExternalSubscriptionURL: string;
 ```
 
-Defined in: [src/globals/SteamClient.ts:286](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L286)
+Defined in: [src/globals/SteamClient.ts:286](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L286)
 
 ***
 
@@ -557,7 +557,7 @@ Defined in: [src/globals/SteamClient.ts:286](https://github.com/shdwmtr/plugutil
 strFlatpakAppID: string;
 ```
 
-Defined in: [src/globals/SteamClient.ts:287](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L287)
+Defined in: [src/globals/SteamClient.ts:287](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L287)
 
 ***
 
@@ -567,7 +567,7 @@ Defined in: [src/globals/SteamClient.ts:287](https://github.com/shdwmtr/plugutil
 strHomepageURL: string;
 ```
 
-Defined in: [src/globals/SteamClient.ts:288](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L288)
+Defined in: [src/globals/SteamClient.ts:288](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L288)
 
 ***
 
@@ -577,7 +577,7 @@ Defined in: [src/globals/SteamClient.ts:288](https://github.com/shdwmtr/plugutil
 strLaunchOptions: string;
 ```
 
-Defined in: [src/globals/SteamClient.ts:289](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L289)
+Defined in: [src/globals/SteamClient.ts:289](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L289)
 
 ***
 
@@ -587,7 +587,7 @@ Defined in: [src/globals/SteamClient.ts:289](https://github.com/shdwmtr/plugutil
 strManualURL: string;
 ```
 
-Defined in: [src/globals/SteamClient.ts:290](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L290)
+Defined in: [src/globals/SteamClient.ts:290](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L290)
 
 ***
 
@@ -597,7 +597,7 @@ Defined in: [src/globals/SteamClient.ts:290](https://github.com/shdwmtr/plugutil
 strOwnerSteamID: string;
 ```
 
-Defined in: [src/globals/SteamClient.ts:291](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L291)
+Defined in: [src/globals/SteamClient.ts:291](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L291)
 
 ***
 
@@ -607,7 +607,7 @@ Defined in: [src/globals/SteamClient.ts:291](https://github.com/shdwmtr/plugutil
 strResolutionOverride: string;
 ```
 
-Defined in: [src/globals/SteamClient.ts:292](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L292)
+Defined in: [src/globals/SteamClient.ts:292](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L292)
 
 ***
 
@@ -617,7 +617,7 @@ Defined in: [src/globals/SteamClient.ts:292](https://github.com/shdwmtr/plugutil
 strSelectedBeta: string;
 ```
 
-Defined in: [src/globals/SteamClient.ts:293](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L293)
+Defined in: [src/globals/SteamClient.ts:293](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L293)
 
 ***
 
@@ -627,7 +627,7 @@ Defined in: [src/globals/SteamClient.ts:293](https://github.com/shdwmtr/plugutil
 strShortcutExe: string;
 ```
 
-Defined in: [src/globals/SteamClient.ts:294](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L294)
+Defined in: [src/globals/SteamClient.ts:294](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L294)
 
 ***
 
@@ -637,7 +637,7 @@ Defined in: [src/globals/SteamClient.ts:294](https://github.com/shdwmtr/plugutil
 strShortcutLaunchOptions: string;
 ```
 
-Defined in: [src/globals/SteamClient.ts:295](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L295)
+Defined in: [src/globals/SteamClient.ts:295](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L295)
 
 ***
 
@@ -647,7 +647,7 @@ Defined in: [src/globals/SteamClient.ts:295](https://github.com/shdwmtr/plugutil
 strShortcutStartDir: string;
 ```
 
-Defined in: [src/globals/SteamClient.ts:296](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L296)
+Defined in: [src/globals/SteamClient.ts:296](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L296)
 
 ***
 
@@ -657,7 +657,7 @@ Defined in: [src/globals/SteamClient.ts:296](https://github.com/shdwmtr/plugutil
 strSteamDeckBlogURL: string;
 ```
 
-Defined in: [src/globals/SteamClient.ts:297](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L297)
+Defined in: [src/globals/SteamClient.ts:297](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L297)
 
 ***
 
@@ -667,7 +667,7 @@ Defined in: [src/globals/SteamClient.ts:297](https://github.com/shdwmtr/plugutil
 unAppID: number;
 ```
 
-Defined in: [src/globals/SteamClient.ts:298](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L298)
+Defined in: [src/globals/SteamClient.ts:298](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L298)
 
 ***
 
@@ -677,7 +677,7 @@ Defined in: [src/globals/SteamClient.ts:298](https://github.com/shdwmtr/plugutil
 vecBetas: any[];
 ```
 
-Defined in: [src/globals/SteamClient.ts:299](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L299)
+Defined in: [src/globals/SteamClient.ts:299](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L299)
 
 ***
 
@@ -687,7 +687,7 @@ Defined in: [src/globals/SteamClient.ts:299](https://github.com/shdwmtr/plugutil
 vecDeckCompatTestResults: any[];
 ```
 
-Defined in: [src/globals/SteamClient.ts:301](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L301)
+Defined in: [src/globals/SteamClient.ts:301](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L301)
 
 ***
 
@@ -697,7 +697,7 @@ Defined in: [src/globals/SteamClient.ts:301](https://github.com/shdwmtr/plugutil
 vecDLC: any[];
 ```
 
-Defined in: [src/globals/SteamClient.ts:300](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L300)
+Defined in: [src/globals/SteamClient.ts:300](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L300)
 
 ***
 
@@ -707,7 +707,7 @@ Defined in: [src/globals/SteamClient.ts:300](https://github.com/shdwmtr/plugutil
 vecLanguages: AppLanguages[];
 ```
 
-Defined in: [src/globals/SteamClient.ts:302](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L302)
+Defined in: [src/globals/SteamClient.ts:302](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L302)
 
 ***
 
@@ -717,7 +717,7 @@ Defined in: [src/globals/SteamClient.ts:302](https://github.com/shdwmtr/plugutil
 vecLegacyCDKeys: any[];
 ```
 
-Defined in: [src/globals/SteamClient.ts:303](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L303)
+Defined in: [src/globals/SteamClient.ts:303](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L303)
 
 ***
 
@@ -727,7 +727,7 @@ Defined in: [src/globals/SteamClient.ts:303](https://github.com/shdwmtr/plugutil
 vecMusicAlbums: any[];
 ```
 
-Defined in: [src/globals/SteamClient.ts:304](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L304)
+Defined in: [src/globals/SteamClient.ts:304](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L304)
 
 ***
 
@@ -737,7 +737,7 @@ Defined in: [src/globals/SteamClient.ts:304](https://github.com/shdwmtr/plugutil
 vecPlatforms: string[];
 ```
 
-Defined in: [src/globals/SteamClient.ts:305](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L305)
+Defined in: [src/globals/SteamClient.ts:305](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L305)
 
 ***
 
@@ -747,4 +747,4 @@ Defined in: [src/globals/SteamClient.ts:305](https://github.com/shdwmtr/plugutil
 vecScreenShots: any[];
 ```
 
-Defined in: [src/globals/SteamClient.ts:306](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L306)
+Defined in: [src/globals/SteamClient.ts:306](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L306)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/Apps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/Apps.md
@@ -4,7 +4,7 @@
 
 # Interface: Apps
 
-Defined in: [src/globals/SteamClient.ts:5](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L5)
+Defined in: [src/globals/SteamClient.ts:5](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L5)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/globals/SteamClient.ts:5](https://github.com/shdwmtr/plugutil/b
 AddShortcut: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:60](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L60)
+Defined in: [src/globals/SteamClient.ts:60](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L60)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/globals/SteamClient.ts:60](https://github.com/shdwmtr/plugutil/
 AddUserTagToApps: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:15](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L15)
+Defined in: [src/globals/SteamClient.ts:15](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L15)
 
 ***
 
@@ -34,7 +34,7 @@ Defined in: [src/globals/SteamClient.ts:15](https://github.com/shdwmtr/plugutil/
 BackupFilesForApp: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:35](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L35)
+Defined in: [src/globals/SteamClient.ts:35](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L35)
 
 ***
 
@@ -44,7 +44,7 @@ Defined in: [src/globals/SteamClient.ts:35](https://github.com/shdwmtr/plugutil/
 BrowseLocalFilesForApp: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:32](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L32)
+Defined in: [src/globals/SteamClient.ts:32](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L32)
 
 ***
 
@@ -54,7 +54,7 @@ Defined in: [src/globals/SteamClient.ts:32](https://github.com/shdwmtr/plugutil/
 BrowseScreenshotForApp: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:34](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L34)
+Defined in: [src/globals/SteamClient.ts:34](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L34)
 
 ***
 
@@ -64,7 +64,7 @@ Defined in: [src/globals/SteamClient.ts:34](https://github.com/shdwmtr/plugutil/
 BrowseScreenshotsForApp: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:33](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L33)
+Defined in: [src/globals/SteamClient.ts:33](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L33)
 
 ***
 
@@ -74,7 +74,7 @@ Defined in: [src/globals/SteamClient.ts:33](https://github.com/shdwmtr/plugutil/
 CancelGameAction: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:98](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L98)
+Defined in: [src/globals/SteamClient.ts:98](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L98)
 
 ***
 
@@ -84,7 +84,7 @@ Defined in: [src/globals/SteamClient.ts:98](https://github.com/shdwmtr/plugutil/
 CancelLaunch: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:92](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L92)
+Defined in: [src/globals/SteamClient.ts:92](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L92)
 
 ***
 
@@ -94,7 +94,7 @@ Defined in: [src/globals/SteamClient.ts:92](https://github.com/shdwmtr/plugutil/
 ClearAndSetUserTagsOnApp: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:18](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L18)
+Defined in: [src/globals/SteamClient.ts:18](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L18)
 
 ***
 
@@ -104,7 +104,7 @@ Defined in: [src/globals/SteamClient.ts:18](https://github.com/shdwmtr/plugutil/
 ClearCustomArtworkForApp: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:75](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L75)
+Defined in: [src/globals/SteamClient.ts:75](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L75)
 
 ***
 
@@ -114,7 +114,7 @@ Defined in: [src/globals/SteamClient.ts:75](https://github.com/shdwmtr/plugutil/
 ClearCustomLogoPositionForApp: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:77](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L77)
+Defined in: [src/globals/SteamClient.ts:77](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L77)
 
 ***
 
@@ -124,7 +124,7 @@ Defined in: [src/globals/SteamClient.ts:77](https://github.com/shdwmtr/plugutil/
 ClearProton: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:108](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L108)
+Defined in: [src/globals/SteamClient.ts:108](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L108)
 
 ***
 
@@ -134,7 +134,7 @@ Defined in: [src/globals/SteamClient.ts:108](https://github.com/shdwmtr/plugutil
 ClearUserTagsOnApps: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:17](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L17)
+Defined in: [src/globals/SteamClient.ts:17](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L17)
 
 ***
 
@@ -144,7 +144,7 @@ Defined in: [src/globals/SteamClient.ts:17](https://github.com/shdwmtr/plugutil/
 ContinueGameAction: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:97](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L97)
+Defined in: [src/globals/SteamClient.ts:97](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L97)
 
 ***
 
@@ -154,7 +154,7 @@ Defined in: [src/globals/SteamClient.ts:97](https://github.com/shdwmtr/plugutil/
 CreateDesktopShortcutForApp: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:37](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L37)
+Defined in: [src/globals/SteamClient.ts:37](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L37)
 
 ***
 
@@ -164,7 +164,7 @@ Defined in: [src/globals/SteamClient.ts:37](https://github.com/shdwmtr/plugutil/
 DeleteLocalScreenshot: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:49](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L49)
+Defined in: [src/globals/SteamClient.ts:49](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L49)
 
 ***
 
@@ -174,7 +174,7 @@ Defined in: [src/globals/SteamClient.ts:49](https://github.com/shdwmtr/plugutil/
 DownloadWorkshopItem: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:44](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L44)
+Defined in: [src/globals/SteamClient.ts:44](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L44)
 
 ***
 
@@ -184,7 +184,7 @@ Defined in: [src/globals/SteamClient.ts:44](https://github.com/shdwmtr/plugutil/
 FetchMarketingMessages: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:110](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L110)
+Defined in: [src/globals/SteamClient.ts:110](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L110)
 
 ***
 
@@ -194,7 +194,7 @@ Defined in: [src/globals/SteamClient.ts:110](https://github.com/shdwmtr/plugutil
 GetAchievementsInTimeRange: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:40](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L40)
+Defined in: [src/globals/SteamClient.ts:40](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L40)
 
 ***
 
@@ -204,7 +204,7 @@ Defined in: [src/globals/SteamClient.ts:40](https://github.com/shdwmtr/plugutil/
 GetActiveGameActions: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:99](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L99)
+Defined in: [src/globals/SteamClient.ts:99](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L99)
 
 ***
 
@@ -214,7 +214,7 @@ Defined in: [src/globals/SteamClient.ts:99](https://github.com/shdwmtr/plugutil/
 GetAllShortcuts: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:58](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L58)
+Defined in: [src/globals/SteamClient.ts:58](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L58)
 
 ***
 
@@ -224,7 +224,7 @@ Defined in: [src/globals/SteamClient.ts:58](https://github.com/shdwmtr/plugutil/
 GetAvailableCompatTools: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:80](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L80)
+Defined in: [src/globals/SteamClient.ts:80](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L80)
 
 ***
 
@@ -234,7 +234,7 @@ Defined in: [src/globals/SteamClient.ts:80](https://github.com/shdwmtr/plugutil/
 GetCachedAppDetails: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:69](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L69)
+Defined in: [src/globals/SteamClient.ts:69](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L69)
 
 ***
 
@@ -244,7 +244,7 @@ Defined in: [src/globals/SteamClient.ts:69](https://github.com/shdwmtr/plugutil/
 GetCloudPendingRemoteOperations: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:107](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L107)
+Defined in: [src/globals/SteamClient.ts:107](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L107)
 
 ***
 
@@ -254,7 +254,7 @@ Defined in: [src/globals/SteamClient.ts:107](https://github.com/shdwmtr/plugutil
 GetConflictingFileTimestamps: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:106](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L106)
+Defined in: [src/globals/SteamClient.ts:106](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L106)
 
 ***
 
@@ -264,7 +264,7 @@ Defined in: [src/globals/SteamClient.ts:106](https://github.com/shdwmtr/plugutil
 GetDetailsForScreenshotUpload: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:47](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L47)
+Defined in: [src/globals/SteamClient.ts:47](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L47)
 
 ***
 
@@ -274,7 +274,7 @@ Defined in: [src/globals/SteamClient.ts:47](https://github.com/shdwmtr/plugutil/
 GetDownloadedWorkshopItems: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:43](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L43)
+Defined in: [src/globals/SteamClient.ts:43](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L43)
 
 ***
 
@@ -284,7 +284,7 @@ Defined in: [src/globals/SteamClient.ts:43](https://github.com/shdwmtr/plugutil/
 GetFriendAchievementsForApp: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:13](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L13)
+Defined in: [src/globals/SteamClient.ts:13](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L13)
 
 ***
 
@@ -294,7 +294,7 @@ Defined in: [src/globals/SteamClient.ts:13](https://github.com/shdwmtr/plugutil/
 GetFriendsWhoPlay: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:51](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L51)
+Defined in: [src/globals/SteamClient.ts:51](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L51)
 
 ***
 
@@ -304,7 +304,7 @@ Defined in: [src/globals/SteamClient.ts:51](https://github.com/shdwmtr/plugutil/
 GetGameActionDetails: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:100](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L100)
+Defined in: [src/globals/SteamClient.ts:100](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L100)
 
 ***
 
@@ -314,7 +314,7 @@ Defined in: [src/globals/SteamClient.ts:100](https://github.com/shdwmtr/plugutil
 GetGameActionForApp: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:101](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L101)
+Defined in: [src/globals/SteamClient.ts:101](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L101)
 
 ***
 
@@ -324,7 +324,7 @@ Defined in: [src/globals/SteamClient.ts:101](https://github.com/shdwmtr/plugutil
 GetLaunchOptionsForApp: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:55](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L55)
+Defined in: [src/globals/SteamClient.ts:55](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L55)
 
 ***
 
@@ -334,7 +334,7 @@ Defined in: [src/globals/SteamClient.ts:55](https://github.com/shdwmtr/plugutil/
 GetLibraryBootstrapData: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:11](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L11)
+Defined in: [src/globals/SteamClient.ts:11](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L11)
 
 ***
 
@@ -344,7 +344,7 @@ Defined in: [src/globals/SteamClient.ts:11](https://github.com/shdwmtr/plugutil/
 GetMyAchievementsForApp: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:14](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L14)
+Defined in: [src/globals/SteamClient.ts:14](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L14)
 
 ***
 
@@ -354,7 +354,7 @@ Defined in: [src/globals/SteamClient.ts:14](https://github.com/shdwmtr/plugutil/
 GetResolutionOverrideForApp: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:56](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L56)
+Defined in: [src/globals/SteamClient.ts:56](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L56)
 
 ***
 
@@ -364,7 +364,7 @@ Defined in: [src/globals/SteamClient.ts:56](https://github.com/shdwmtr/plugutil/
 GetScreenshotsInTimeRange: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:50](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L50)
+Defined in: [src/globals/SteamClient.ts:50](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L50)
 
 ***
 
@@ -374,7 +374,7 @@ Defined in: [src/globals/SteamClient.ts:50](https://github.com/shdwmtr/plugutil/
 GetShortcutData: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:59](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L59)
+Defined in: [src/globals/SteamClient.ts:59](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L59)
 
 ***
 
@@ -384,7 +384,7 @@ Defined in: [src/globals/SteamClient.ts:59](https://github.com/shdwmtr/plugutil/
 GetSoundtrackDetails: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:53](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L53)
+Defined in: [src/globals/SteamClient.ts:53](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L53)
 
 ***
 
@@ -394,7 +394,7 @@ Defined in: [src/globals/SteamClient.ts:53](https://github.com/shdwmtr/plugutil/
 GetStoreTagLocalization: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:54](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L54)
+Defined in: [src/globals/SteamClient.ts:54](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L54)
 
 ***
 
@@ -404,7 +404,7 @@ Defined in: [src/globals/SteamClient.ts:54](https://github.com/shdwmtr/plugutil/
 GetSubscribedWorkshopItems: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:41](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L41)
+Defined in: [src/globals/SteamClient.ts:41](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L41)
 
 ***
 
@@ -414,7 +414,7 @@ Defined in: [src/globals/SteamClient.ts:41](https://github.com/shdwmtr/plugutil/
 InstallApp: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:88](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L88)
+Defined in: [src/globals/SteamClient.ts:88](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L88)
 
 ***
 
@@ -424,7 +424,7 @@ Defined in: [src/globals/SteamClient.ts:88](https://github.com/shdwmtr/plugutil/
 InstallFlatpakAppAndCreateShortcut: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:62](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L62)
+Defined in: [src/globals/SteamClient.ts:62](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L62)
 
 ***
 
@@ -434,7 +434,7 @@ Defined in: [src/globals/SteamClient.ts:62](https://github.com/shdwmtr/plugutil/
 JoinAppContentBeta: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:38](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L38)
+Defined in: [src/globals/SteamClient.ts:38](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L38)
 
 ***
 
@@ -444,7 +444,7 @@ Defined in: [src/globals/SteamClient.ts:38](https://github.com/shdwmtr/plugutil/
 JoinAppContentBetaByPassword: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:39](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L39)
+Defined in: [src/globals/SteamClient.ts:39](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L39)
 
 ***
 
@@ -454,7 +454,7 @@ Defined in: [src/globals/SteamClient.ts:39](https://github.com/shdwmtr/plugutil/
 ListFlatpakApps: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:63](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L63)
+Defined in: [src/globals/SteamClient.ts:63](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L63)
 
 ***
 
@@ -464,7 +464,7 @@ Defined in: [src/globals/SteamClient.ts:63](https://github.com/shdwmtr/plugutil/
 LoadEula: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:105](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L105)
+Defined in: [src/globals/SteamClient.ts:105](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L105)
 
 ***
 
@@ -474,7 +474,7 @@ Defined in: [src/globals/SteamClient.ts:105](https://github.com/shdwmtr/plugutil
 MarkEulaAccepted: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:103](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L103)
+Defined in: [src/globals/SteamClient.ts:103](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L103)
 
 ***
 
@@ -484,7 +484,7 @@ Defined in: [src/globals/SteamClient.ts:103](https://github.com/shdwmtr/plugutil
 MarkEulaRejected: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:104](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L104)
+Defined in: [src/globals/SteamClient.ts:104](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L104)
 
 ***
 
@@ -494,7 +494,7 @@ Defined in: [src/globals/SteamClient.ts:104](https://github.com/shdwmtr/plugutil
 MarkMarketingMessageSeen: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:111](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L111)
+Defined in: [src/globals/SteamClient.ts:111](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L111)
 
 ***
 
@@ -504,7 +504,7 @@ Defined in: [src/globals/SteamClient.ts:111](https://github.com/shdwmtr/plugutil
 OpenAppSettingsDialog: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:119](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L119)
+Defined in: [src/globals/SteamClient.ts:119](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L119)
 
 ***
 
@@ -514,7 +514,7 @@ Defined in: [src/globals/SteamClient.ts:119](https://github.com/shdwmtr/plugutil
 PromptToChangeShortcut: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:86](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L86)
+Defined in: [src/globals/SteamClient.ts:86](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L86)
 
 ***
 
@@ -524,7 +524,7 @@ Defined in: [src/globals/SteamClient.ts:86](https://github.com/shdwmtr/plugutil/
 PromptToSelectShortcutIcon: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:87](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L87)
+Defined in: [src/globals/SteamClient.ts:87](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L87)
 
 ***
 
@@ -534,7 +534,7 @@ Defined in: [src/globals/SteamClient.ts:87](https://github.com/shdwmtr/plugutil/
 RegisterForAchievementChanges: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:12](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L12)
+Defined in: [src/globals/SteamClient.ts:12](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L12)
 
 ***
 
@@ -544,7 +544,7 @@ Defined in: [src/globals/SteamClient.ts:12](https://github.com/shdwmtr/plugutil/
 RegisterForAppDetails: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L7)
+Defined in: [src/globals/SteamClient.ts:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L7)
 
 ***
 
@@ -554,7 +554,7 @@ Defined in: [src/globals/SteamClient.ts:7](https://github.com/shdwmtr/plugutil/b
 RegisterForAppOverviewChanges: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:6](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L6)
+Defined in: [src/globals/SteamClient.ts:6](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L6)
 
 ***
 
@@ -564,7 +564,7 @@ Defined in: [src/globals/SteamClient.ts:6](https://github.com/shdwmtr/plugutil/b
 RegisterForGameActionEnd: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:114](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L114)
+Defined in: [src/globals/SteamClient.ts:114](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L114)
 
 ***
 
@@ -574,7 +574,7 @@ Defined in: [src/globals/SteamClient.ts:114](https://github.com/shdwmtr/plugutil
 RegisterForGameActionShowError: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:117](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L117)
+Defined in: [src/globals/SteamClient.ts:117](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L117)
 
 ***
 
@@ -584,7 +584,7 @@ Defined in: [src/globals/SteamClient.ts:117](https://github.com/shdwmtr/plugutil
 RegisterForGameActionShowUI: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:118](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L118)
+Defined in: [src/globals/SteamClient.ts:118](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L118)
 
 ***
 
@@ -594,7 +594,7 @@ Defined in: [src/globals/SteamClient.ts:118](https://github.com/shdwmtr/plugutil
 RegisterForGameActionStart: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:113](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L113)
+Defined in: [src/globals/SteamClient.ts:113](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L113)
 
 ***
 
@@ -604,7 +604,7 @@ Defined in: [src/globals/SteamClient.ts:113](https://github.com/shdwmtr/plugutil
 RegisterForGameActionTaskChange: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:115](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L115)
+Defined in: [src/globals/SteamClient.ts:115](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L115)
 
 ***
 
@@ -614,7 +614,7 @@ Defined in: [src/globals/SteamClient.ts:115](https://github.com/shdwmtr/plugutil
 RegisterForGameActionUserRequest: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:116](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L116)
+Defined in: [src/globals/SteamClient.ts:116](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L116)
 
 ***
 
@@ -624,7 +624,7 @@ Defined in: [src/globals/SteamClient.ts:116](https://github.com/shdwmtr/plugutil
 RegisterForLocalizationChanges: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L8)
+Defined in: [src/globals/SteamClient.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L8)
 
 ***
 
@@ -634,7 +634,7 @@ Defined in: [src/globals/SteamClient.ts:8](https://github.com/shdwmtr/plugutil/b
 RegisterForMarketingMessages: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:109](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L109)
+Defined in: [src/globals/SteamClient.ts:109](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L109)
 
 ***
 
@@ -644,7 +644,7 @@ Defined in: [src/globals/SteamClient.ts:109](https://github.com/shdwmtr/plugutil
 RegisterForWorkshopChanges: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L9)
+Defined in: [src/globals/SteamClient.ts:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L9)
 
 ***
 
@@ -654,7 +654,7 @@ Defined in: [src/globals/SteamClient.ts:9](https://github.com/shdwmtr/plugutil/b
 RegisterForWorkshopItemDownloads: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:10](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L10)
+Defined in: [src/globals/SteamClient.ts:10](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L10)
 
 ***
 
@@ -664,7 +664,7 @@ Defined in: [src/globals/SteamClient.ts:10](https://github.com/shdwmtr/plugutil/
 RemoveShortcut: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:61](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L61)
+Defined in: [src/globals/SteamClient.ts:61](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L61)
 
 ***
 
@@ -674,7 +674,7 @@ Defined in: [src/globals/SteamClient.ts:61](https://github.com/shdwmtr/plugutil/
 RemoveUserTagFromApps: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:16](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L16)
+Defined in: [src/globals/SteamClient.ts:16](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L16)
 
 ***
 
@@ -684,7 +684,7 @@ Defined in: [src/globals/SteamClient.ts:16](https://github.com/shdwmtr/plugutil/
 ReportLibraryAssetCacheMiss: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:71](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L71)
+Defined in: [src/globals/SteamClient.ts:71](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L71)
 
 ***
 
@@ -694,7 +694,7 @@ Defined in: [src/globals/SteamClient.ts:71](https://github.com/shdwmtr/plugutil/
 ReportMarketingMessageSeen: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:112](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L112)
+Defined in: [src/globals/SteamClient.ts:112](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L112)
 
 ***
 
@@ -704,7 +704,7 @@ Defined in: [src/globals/SteamClient.ts:112](https://github.com/shdwmtr/plugutil
 RequestIconDataForApp: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:78](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L78)
+Defined in: [src/globals/SteamClient.ts:78](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L78)
 
 ***
 
@@ -714,7 +714,7 @@ Defined in: [src/globals/SteamClient.ts:78](https://github.com/shdwmtr/plugutil/
 RequestLegacyCDKeysForApp: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:52](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L52)
+Defined in: [src/globals/SteamClient.ts:52](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L52)
 
 ***
 
@@ -724,7 +724,7 @@ Defined in: [src/globals/SteamClient.ts:52](https://github.com/shdwmtr/plugutil/
 ResetHiddenState: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:20](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L20)
+Defined in: [src/globals/SteamClient.ts:20](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L20)
 
 ***
 
@@ -734,7 +734,7 @@ Defined in: [src/globals/SteamClient.ts:20](https://github.com/shdwmtr/plugutil/
 RunGame: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:89](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L89)
+Defined in: [src/globals/SteamClient.ts:89](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L89)
 
 ***
 
@@ -744,7 +744,7 @@ Defined in: [src/globals/SteamClient.ts:89](https://github.com/shdwmtr/plugutil/
 SaveAchievementProgressCache: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:72](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L72)
+Defined in: [src/globals/SteamClient.ts:72](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L72)
 
 ***
 
@@ -754,7 +754,7 @@ Defined in: [src/globals/SteamClient.ts:72](https://github.com/shdwmtr/plugutil/
 ScanForShortcuts: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:57](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L57)
+Defined in: [src/globals/SteamClient.ts:57](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L57)
 
 ***
 
@@ -764,7 +764,7 @@ Defined in: [src/globals/SteamClient.ts:57](https://github.com/shdwmtr/plugutil/
 SetAppAutoUpdateBehavior: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:24](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L24)
+Defined in: [src/globals/SteamClient.ts:24](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L24)
 
 ***
 
@@ -774,7 +774,7 @@ Defined in: [src/globals/SteamClient.ts:24](https://github.com/shdwmtr/plugutil/
 SetAppBackgroundDownloadsBehavior: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:25](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L25)
+Defined in: [src/globals/SteamClient.ts:25](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L25)
 
 ***
 
@@ -784,7 +784,7 @@ Defined in: [src/globals/SteamClient.ts:25](https://github.com/shdwmtr/plugutil/
 SetAppCurrentLanguage: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:23](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L23)
+Defined in: [src/globals/SteamClient.ts:23](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L23)
 
 ***
 
@@ -794,7 +794,7 @@ Defined in: [src/globals/SteamClient.ts:23](https://github.com/shdwmtr/plugutil/
 SetAppHidden: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:19](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L19)
+Defined in: [src/globals/SteamClient.ts:19](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L19)
 
 ***
 
@@ -804,7 +804,7 @@ Defined in: [src/globals/SteamClient.ts:19](https://github.com/shdwmtr/plugutil/
 SetAppLaunchOptions: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:21](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L21)
+Defined in: [src/globals/SteamClient.ts:21](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L21)
 
 ***
 
@@ -814,7 +814,7 @@ Defined in: [src/globals/SteamClient.ts:21](https://github.com/shdwmtr/plugutil/
 SetAppResolutionOverride: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:22](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L22)
+Defined in: [src/globals/SteamClient.ts:22](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L22)
 
 ***
 
@@ -824,7 +824,7 @@ Defined in: [src/globals/SteamClient.ts:22](https://github.com/shdwmtr/plugutil/
 SetCachedAppDetails: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:70](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L70)
+Defined in: [src/globals/SteamClient.ts:70](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L70)
 
 ***
 
@@ -834,7 +834,7 @@ Defined in: [src/globals/SteamClient.ts:70](https://github.com/shdwmtr/plugutil/
 SetControllerRumblePreference: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:68](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L68)
+Defined in: [src/globals/SteamClient.ts:68](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L68)
 
 ***
 
@@ -844,7 +844,7 @@ Defined in: [src/globals/SteamClient.ts:68](https://github.com/shdwmtr/plugutil/
 SetCustomArtworkForApp: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:74](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L74)
+Defined in: [src/globals/SteamClient.ts:74](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L74)
 
 ***
 
@@ -854,7 +854,7 @@ Defined in: [src/globals/SteamClient.ts:74](https://github.com/shdwmtr/plugutil/
 SetCustomLogoPositionForApp: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:76](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L76)
+Defined in: [src/globals/SteamClient.ts:76](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L76)
 
 ***
 
@@ -864,7 +864,7 @@ Defined in: [src/globals/SteamClient.ts:76](https://github.com/shdwmtr/plugutil/
 SetDLCEnabled: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:96](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L96)
+Defined in: [src/globals/SteamClient.ts:96](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L96)
 
 ***
 
@@ -874,7 +874,7 @@ Defined in: [src/globals/SteamClient.ts:96](https://github.com/shdwmtr/plugutil/
 SetLocalScreenshotCaption: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:45](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L45)
+Defined in: [src/globals/SteamClient.ts:45](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L45)
 
 ***
 
@@ -884,7 +884,7 @@ Defined in: [src/globals/SteamClient.ts:45](https://github.com/shdwmtr/plugutil/
 SetLocalScreenshotSpoiler: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:46](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L46)
+Defined in: [src/globals/SteamClient.ts:46](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L46)
 
 ***
 
@@ -894,7 +894,7 @@ Defined in: [src/globals/SteamClient.ts:46](https://github.com/shdwmtr/plugutil/
 SetShortcutExe: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:82](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L82)
+Defined in: [src/globals/SteamClient.ts:82](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L82)
 
 ***
 
@@ -904,7 +904,7 @@ Defined in: [src/globals/SteamClient.ts:82](https://github.com/shdwmtr/plugutil/
 SetShortcutIsVR: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:85](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L85)
+Defined in: [src/globals/SteamClient.ts:85](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L85)
 
 ***
 
@@ -914,7 +914,7 @@ Defined in: [src/globals/SteamClient.ts:85](https://github.com/shdwmtr/plugutil/
 SetShortcutLaunchOptions: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:84](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L84)
+Defined in: [src/globals/SteamClient.ts:84](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L84)
 
 ***
 
@@ -924,7 +924,7 @@ Defined in: [src/globals/SteamClient.ts:84](https://github.com/shdwmtr/plugutil/
 SetShortcutName: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:81](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L81)
+Defined in: [src/globals/SteamClient.ts:81](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L81)
 
 ***
 
@@ -934,7 +934,7 @@ Defined in: [src/globals/SteamClient.ts:81](https://github.com/shdwmtr/plugutil/
 SetShortcutStartDir: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:83](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L83)
+Defined in: [src/globals/SteamClient.ts:83](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L83)
 
 ***
 
@@ -944,7 +944,7 @@ Defined in: [src/globals/SteamClient.ts:83](https://github.com/shdwmtr/plugutil/
 SetStreamingClientForApp: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:73](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L73)
+Defined in: [src/globals/SteamClient.ts:73](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L73)
 
 ***
 
@@ -954,7 +954,7 @@ Defined in: [src/globals/SteamClient.ts:73](https://github.com/shdwmtr/plugutil/
 SetThirdPartyControllerConfiguration: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:66](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L66)
+Defined in: [src/globals/SteamClient.ts:66](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L66)
 
 ***
 
@@ -964,7 +964,7 @@ Defined in: [src/globals/SteamClient.ts:66](https://github.com/shdwmtr/plugutil/
 ShowControllerConfigurator: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:65](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L65)
+Defined in: [src/globals/SteamClient.ts:65](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L65)
 
 ***
 
@@ -974,7 +974,7 @@ Defined in: [src/globals/SteamClient.ts:65](https://github.com/shdwmtr/plugutil/
 ShowStore: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:95](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L95)
+Defined in: [src/globals/SteamClient.ts:95](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L95)
 
 ***
 
@@ -984,7 +984,7 @@ Defined in: [src/globals/SteamClient.ts:95](https://github.com/shdwmtr/plugutil/
 SkipShaderProcessing: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:102](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L102)
+Defined in: [src/globals/SteamClient.ts:102](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L102)
 
 ***
 
@@ -994,7 +994,7 @@ Defined in: [src/globals/SteamClient.ts:102](https://github.com/shdwmtr/plugutil
 SpecifyCompatTool: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:79](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L79)
+Defined in: [src/globals/SteamClient.ts:79](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L79)
 
 ***
 
@@ -1004,7 +1004,7 @@ Defined in: [src/globals/SteamClient.ts:79](https://github.com/shdwmtr/plugutil/
 StreamGame: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:91](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L91)
+Defined in: [src/globals/SteamClient.ts:91](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L91)
 
 ***
 
@@ -1014,7 +1014,7 @@ Defined in: [src/globals/SteamClient.ts:91](https://github.com/shdwmtr/plugutil/
 SubscribeWorkshopItem: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:42](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L42)
+Defined in: [src/globals/SteamClient.ts:42](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L42)
 
 ***
 
@@ -1024,7 +1024,7 @@ Defined in: [src/globals/SteamClient.ts:42](https://github.com/shdwmtr/plugutil/
 TerminateApp: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:93](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L93)
+Defined in: [src/globals/SteamClient.ts:93](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L93)
 
 ***
 
@@ -1034,7 +1034,7 @@ Defined in: [src/globals/SteamClient.ts:93](https://github.com/shdwmtr/plugutil/
 ToggleAllowDesktopConfiguration: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:67](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L67)
+Defined in: [src/globals/SteamClient.ts:67](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L67)
 
 ***
 
@@ -1044,7 +1044,7 @@ Defined in: [src/globals/SteamClient.ts:67](https://github.com/shdwmtr/plugutil/
 ToggleAppFamilyBlockedState: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:26](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L26)
+Defined in: [src/globals/SteamClient.ts:26](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L26)
 
 ***
 
@@ -1054,7 +1054,7 @@ Defined in: [src/globals/SteamClient.ts:26](https://github.com/shdwmtr/plugutil/
 ToggleAppSteamCloudEnabled: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:27](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L27)
+Defined in: [src/globals/SteamClient.ts:27](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L27)
 
 ***
 
@@ -1064,7 +1064,7 @@ Defined in: [src/globals/SteamClient.ts:27](https://github.com/shdwmtr/plugutil/
 ToggleAppSteamCloudSyncOnSuspendEnabled: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:28](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L28)
+Defined in: [src/globals/SteamClient.ts:28](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L28)
 
 ***
 
@@ -1074,7 +1074,7 @@ Defined in: [src/globals/SteamClient.ts:28](https://github.com/shdwmtr/plugutil/
 ToggleEnableDesktopTheatreForApp: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:31](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L31)
+Defined in: [src/globals/SteamClient.ts:31](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L31)
 
 ***
 
@@ -1084,7 +1084,7 @@ Defined in: [src/globals/SteamClient.ts:31](https://github.com/shdwmtr/plugutil/
 ToggleEnableSteamOverlayForApp: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:30](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L30)
+Defined in: [src/globals/SteamClient.ts:30](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L30)
 
 ***
 
@@ -1094,7 +1094,7 @@ Defined in: [src/globals/SteamClient.ts:30](https://github.com/shdwmtr/plugutil/
 ToggleOverrideResolutionForInternalDisplay: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:29](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L29)
+Defined in: [src/globals/SteamClient.ts:29](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L29)
 
 ***
 
@@ -1104,7 +1104,7 @@ Defined in: [src/globals/SteamClient.ts:29](https://github.com/shdwmtr/plugutil/
 UninstallApps: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:94](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L94)
+Defined in: [src/globals/SteamClient.ts:94](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L94)
 
 ***
 
@@ -1114,7 +1114,7 @@ Defined in: [src/globals/SteamClient.ts:94](https://github.com/shdwmtr/plugutil/
 UninstallFlatpakApp: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:64](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L64)
+Defined in: [src/globals/SteamClient.ts:64](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L64)
 
 ***
 
@@ -1124,7 +1124,7 @@ Defined in: [src/globals/SteamClient.ts:64](https://github.com/shdwmtr/plugutil/
 UploadLocalScreenshot: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:48](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L48)
+Defined in: [src/globals/SteamClient.ts:48](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L48)
 
 ***
 
@@ -1134,7 +1134,7 @@ Defined in: [src/globals/SteamClient.ts:48](https://github.com/shdwmtr/plugutil/
 VerifyApp: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:90](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L90)
+Defined in: [src/globals/SteamClient.ts:90](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L90)
 
 ***
 
@@ -1144,4 +1144,4 @@ Defined in: [src/globals/SteamClient.ts:90](https://github.com/shdwmtr/plugutil/
 VerifyFilesForApp: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:36](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L36)
+Defined in: [src/globals/SteamClient.ts:36](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L36)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/ButtonItemProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/ButtonItemProps.md
@@ -4,7 +4,7 @@
 
 # Interface: ButtonItemProps
 
-Defined in: [src/components/ButtonItem.ts:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ButtonItem.ts#L7)
+Defined in: [src/components/ButtonItem.ts:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ButtonItem.ts#L7)
 
 ## Extends
 
@@ -18,7 +18,7 @@ Defined in: [src/components/ButtonItem.ts:7](https://github.com/shdwmtr/plugutil
 optional bottomSeparator: "standard" | "thick" | "none";
 ```
 
-Defined in: [src/components/Item.ts:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L9)
+Defined in: [src/components/Item.ts:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L9)
 
 #### Inherited from
 
@@ -34,7 +34,7 @@ ItemProps.bottomSeparator
 optional children: ReactNode;
 ```
 
-Defined in: [src/components/Item.ts:6](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L6)
+Defined in: [src/components/Item.ts:6](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L6)
 
 #### Inherited from
 
@@ -50,7 +50,7 @@ ItemProps.children
 optional description: ReactNode;
 ```
 
-Defined in: [src/components/Item.ts:5](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L5)
+Defined in: [src/components/Item.ts:5](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L5)
 
 #### Inherited from
 
@@ -66,7 +66,7 @@ ItemProps.description
 optional disabled: boolean;
 ```
 
-Defined in: [src/components/ButtonItem.ts:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ButtonItem.ts#L9)
+Defined in: [src/components/ButtonItem.ts:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ButtonItem.ts#L9)
 
 ***
 
@@ -76,7 +76,7 @@ Defined in: [src/components/ButtonItem.ts:9](https://github.com/shdwmtr/plugutil
 optional highlightOnFocus: boolean;
 ```
 
-Defined in: [src/components/Item.ts:12](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L12)
+Defined in: [src/components/Item.ts:12](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L12)
 
 #### Inherited from
 
@@ -92,7 +92,7 @@ ItemProps.highlightOnFocus
 optional icon: ReactNode;
 ```
 
-Defined in: [src/components/Item.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L8)
+Defined in: [src/components/Item.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L8)
 
 #### Inherited from
 
@@ -108,7 +108,7 @@ ItemProps.icon
 optional indentLevel: number;
 ```
 
-Defined in: [src/components/Item.ts:10](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L10)
+Defined in: [src/components/Item.ts:10](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L10)
 
 #### Inherited from
 
@@ -124,7 +124,7 @@ ItemProps.indentLevel
 optional label: ReactNode;
 ```
 
-Defined in: [src/components/Item.ts:4](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L4)
+Defined in: [src/components/Item.ts:4](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L4)
 
 #### Inherited from
 
@@ -140,7 +140,7 @@ ItemProps.label
 optional layout: "below" | "inline";
 ```
 
-Defined in: [src/components/Item.ts:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L7)
+Defined in: [src/components/Item.ts:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L7)
 
 #### Inherited from
 
@@ -156,7 +156,7 @@ ItemProps.layout
 optional tooltip: string;
 ```
 
-Defined in: [src/components/Item.ts:11](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L11)
+Defined in: [src/components/Item.ts:11](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L11)
 
 #### Inherited from
 
@@ -172,7 +172,7 @@ ItemProps.tooltip
 optional onClick(e: MouseEvent): void
 ```
 
-Defined in: [src/components/ButtonItem.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ButtonItem.ts#L8)
+Defined in: [src/components/ButtonItem.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ButtonItem.ts#L8)
 
 #### Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/ButtonProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/ButtonProps.md
@@ -4,7 +4,7 @@
 
 # Interface: ButtonProps
 
-Defined in: [src/components/Button.ts:5](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Button.ts#L5)
+Defined in: [src/components/Button.ts:5](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Button.ts#L5)
 
 ## Extends
 
@@ -18,7 +18,7 @@ Defined in: [src/components/Button.ts:5](https://github.com/shdwmtr/plugutil/blo
 optional actionDescriptionMap: ActionDescriptionMap;
 ```
 
-Defined in: [src/components/FooterLegend.ts:53](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L53)
+Defined in: [src/components/FooterLegend.ts:53](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L53)
 
 #### Inherited from
 
@@ -32,7 +32,7 @@ Defined in: [src/components/FooterLegend.ts:53](https://github.com/shdwmtr/plugu
 optional children: ReactNode;
 ```
 
-Defined in: [src/components/Dialog.ts:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L9)
+Defined in: [src/components/Dialog.ts:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L9)
 
 #### Inherited from
 
@@ -46,7 +46,7 @@ Defined in: [src/components/Dialog.ts:9](https://github.com/shdwmtr/plugutil/blo
 optional className: string;
 ```
 
-Defined in: [src/components/Dialog.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L8)
+Defined in: [src/components/Dialog.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L8)
 
 #### Inherited from
 
@@ -60,7 +60,7 @@ Defined in: [src/components/Dialog.ts:8](https://github.com/shdwmtr/plugutil/blo
 optional disabled: boolean;
 ```
 
-Defined in: [src/components/Dialog.ts:30](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L30)
+Defined in: [src/components/Dialog.ts:30](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L30)
 
 Disables the button - assigned `on*` methods will not be invoked if clicked.
 
@@ -85,7 +85,7 @@ focusable.
 optional focusable: boolean;
 ```
 
-Defined in: [src/components/Dialog.ts:40](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L40)
+Defined in: [src/components/Dialog.ts:40](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L40)
 
 Enables/disables the navigation based focus on button - you won't be able to navigate to
 it via the gamepad or keyboard.
@@ -121,7 +121,7 @@ Defined in: node\_modules/@types/react/index.d.ts:137
 optional noFocusRing: boolean;
 ```
 
-Defined in: [src/components/Dialog.ts:19](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L19)
+Defined in: [src/components/Dialog.ts:19](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L19)
 
 Enables/disables the focus around the button.
 
@@ -141,7 +141,7 @@ Default value depends on context, so setting it to `false` will enable it.
 optional onButtonDown: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:59](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L59)
+Defined in: [src/components/FooterLegend.ts:59](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L59)
 
 #### Parameters
 
@@ -165,7 +165,7 @@ Defined in: [src/components/FooterLegend.ts:59](https://github.com/shdwmtr/plugu
 optional onButtonUp: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:60](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L60)
+Defined in: [src/components/FooterLegend.ts:60](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L60)
 
 #### Parameters
 
@@ -189,7 +189,7 @@ Defined in: [src/components/FooterLegend.ts:60](https://github.com/shdwmtr/plugu
 optional onCancelActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:55](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L55)
+Defined in: [src/components/FooterLegend.ts:55](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L55)
 
 #### Inherited from
 
@@ -203,7 +203,7 @@ Defined in: [src/components/FooterLegend.ts:55](https://github.com/shdwmtr/plugu
 optional onCancelButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:62](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L62)
+Defined in: [src/components/FooterLegend.ts:62](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L62)
 
 #### Parameters
 
@@ -227,7 +227,7 @@ Defined in: [src/components/FooterLegend.ts:62](https://github.com/shdwmtr/plugu
 optional onGamepadBlur: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:67](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L67)
+Defined in: [src/components/FooterLegend.ts:67](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L67)
 
 #### Parameters
 
@@ -251,7 +251,7 @@ Defined in: [src/components/FooterLegend.ts:67](https://github.com/shdwmtr/plugu
 optional onGamepadDirection: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:65](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L65)
+Defined in: [src/components/FooterLegend.ts:65](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L65)
 
 #### Parameters
 
@@ -275,7 +275,7 @@ Defined in: [src/components/FooterLegend.ts:65](https://github.com/shdwmtr/plugu
 optional onGamepadFocus: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:66](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L66)
+Defined in: [src/components/FooterLegend.ts:66](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L66)
 
 #### Parameters
 
@@ -299,7 +299,7 @@ Defined in: [src/components/FooterLegend.ts:66](https://github.com/shdwmtr/plugu
 optional onMenuActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:58](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L58)
+Defined in: [src/components/FooterLegend.ts:58](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L58)
 
 #### Inherited from
 
@@ -313,7 +313,7 @@ Defined in: [src/components/FooterLegend.ts:58](https://github.com/shdwmtr/plugu
 optional onMenuButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:68](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L68)
+Defined in: [src/components/FooterLegend.ts:68](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L68)
 
 #### Parameters
 
@@ -337,7 +337,7 @@ Defined in: [src/components/FooterLegend.ts:68](https://github.com/shdwmtr/plugu
 optional onOKActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:54](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L54)
+Defined in: [src/components/FooterLegend.ts:54](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L54)
 
 #### Inherited from
 
@@ -351,7 +351,7 @@ Defined in: [src/components/FooterLegend.ts:54](https://github.com/shdwmtr/plugu
 optional onOKButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:61](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L61)
+Defined in: [src/components/FooterLegend.ts:61](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L61)
 
 #### Parameters
 
@@ -375,7 +375,7 @@ Defined in: [src/components/FooterLegend.ts:61](https://github.com/shdwmtr/plugu
 optional onOptionsActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:57](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L57)
+Defined in: [src/components/FooterLegend.ts:57](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L57)
 
 #### Inherited from
 
@@ -389,7 +389,7 @@ Defined in: [src/components/FooterLegend.ts:57](https://github.com/shdwmtr/plugu
 optional onOptionsButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:64](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L64)
+Defined in: [src/components/FooterLegend.ts:64](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L64)
 
 #### Parameters
 
@@ -413,7 +413,7 @@ Defined in: [src/components/FooterLegend.ts:64](https://github.com/shdwmtr/plugu
 optional onSecondaryActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:56](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L56)
+Defined in: [src/components/FooterLegend.ts:56](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L56)
 
 #### Inherited from
 
@@ -427,7 +427,7 @@ Defined in: [src/components/FooterLegend.ts:56](https://github.com/shdwmtr/plugu
 optional onSecondaryButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:63](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L63)
+Defined in: [src/components/FooterLegend.ts:63](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L63)
 
 #### Parameters
 
@@ -465,7 +465,7 @@ Defined in: node\_modules/@types/react/index.d.ts:140
 optional style: CSSProperties;
 ```
 
-Defined in: [src/components/Dialog.ts:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L7)
+Defined in: [src/components/Dialog.ts:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L7)
 
 #### Inherited from
 
@@ -479,7 +479,7 @@ Defined in: [src/components/Dialog.ts:7](https://github.com/shdwmtr/plugutil/blo
 optional onClick(e: MouseEvent): void
 ```
 
-Defined in: [src/components/Dialog.ts:42](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L42)
+Defined in: [src/components/Dialog.ts:42](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L42)
 
 #### Parameters
 
@@ -503,7 +503,7 @@ Defined in: [src/components/Dialog.ts:42](https://github.com/shdwmtr/plugutil/bl
 optional onMouseDown(e: MouseEvent): void
 ```
 
-Defined in: [src/components/Dialog.ts:46](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L46)
+Defined in: [src/components/Dialog.ts:46](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L46)
 
 #### Parameters
 
@@ -527,7 +527,7 @@ Defined in: [src/components/Dialog.ts:46](https://github.com/shdwmtr/plugutil/bl
 optional onMouseUp(e: MouseEvent): void
 ```
 
-Defined in: [src/components/Dialog.ts:47](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L47)
+Defined in: [src/components/Dialog.ts:47](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L47)
 
 #### Parameters
 
@@ -551,7 +551,7 @@ Defined in: [src/components/Dialog.ts:47](https://github.com/shdwmtr/plugutil/bl
 optional onPointerCancel(e: PointerEvent): void
 ```
 
-Defined in: [src/components/Dialog.ts:45](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L45)
+Defined in: [src/components/Dialog.ts:45](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L45)
 
 #### Parameters
 
@@ -575,7 +575,7 @@ Defined in: [src/components/Dialog.ts:45](https://github.com/shdwmtr/plugutil/bl
 optional onPointerDown(e: PointerEvent): void
 ```
 
-Defined in: [src/components/Dialog.ts:43](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L43)
+Defined in: [src/components/Dialog.ts:43](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L43)
 
 #### Parameters
 
@@ -599,7 +599,7 @@ Defined in: [src/components/Dialog.ts:43](https://github.com/shdwmtr/plugutil/bl
 optional onPointerUp(e: PointerEvent): void
 ```
 
-Defined in: [src/components/Dialog.ts:44](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L44)
+Defined in: [src/components/Dialog.ts:44](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L44)
 
 #### Parameters
 
@@ -623,7 +623,7 @@ Defined in: [src/components/Dialog.ts:44](https://github.com/shdwmtr/plugutil/bl
 optional onSubmit(e: SubmitEvent): void
 ```
 
-Defined in: [src/components/Dialog.ts:51](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L51)
+Defined in: [src/components/Dialog.ts:51](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L51)
 
 #### Parameters
 
@@ -647,7 +647,7 @@ Defined in: [src/components/Dialog.ts:51](https://github.com/shdwmtr/plugutil/bl
 optional onTouchCancel(e: TouchEvent): void
 ```
 
-Defined in: [src/components/Dialog.ts:50](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L50)
+Defined in: [src/components/Dialog.ts:50](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L50)
 
 #### Parameters
 
@@ -671,7 +671,7 @@ Defined in: [src/components/Dialog.ts:50](https://github.com/shdwmtr/plugutil/bl
 optional onTouchEnd(e: TouchEvent): void
 ```
 
-Defined in: [src/components/Dialog.ts:49](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L49)
+Defined in: [src/components/Dialog.ts:49](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L49)
 
 #### Parameters
 
@@ -695,7 +695,7 @@ Defined in: [src/components/Dialog.ts:49](https://github.com/shdwmtr/plugutil/bl
 optional onTouchStart(e: TouchEvent): void
 ```
 
-Defined in: [src/components/Dialog.ts:48](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L48)
+Defined in: [src/components/Dialog.ts:48](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L48)
 
 #### Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/CarouselProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/CarouselProps.md
@@ -4,7 +4,7 @@
 
 # Interface: CarouselProps
 
-Defined in: [src/components/Carousel.ts:5](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Carousel.ts#L5)
+Defined in: [src/components/Carousel.ts:5](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Carousel.ts#L5)
 
 ## Extends
 
@@ -1081,7 +1081,7 @@ HTMLAttributes.autoCorrect
 optional autoFocus: boolean;
 ```
 
-Defined in: [src/components/Carousel.ts:6](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Carousel.ts#L6)
+Defined in: [src/components/Carousel.ts:6](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Carousel.ts#L6)
 
 ***
 
@@ -1291,7 +1291,7 @@ HTMLAttributes.draggable
 optional enableBumperPaging: boolean;
 ```
 
-Defined in: [src/components/Carousel.ts:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Carousel.ts#L7)
+Defined in: [src/components/Carousel.ts:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Carousel.ts#L7)
 
 ***
 
@@ -1301,7 +1301,7 @@ Defined in: [src/components/Carousel.ts:7](https://github.com/shdwmtr/plugutil/b
 optional fnDoesItemTakeFocus: (...unknown: any[]) => boolean;
 ```
 
-Defined in: [src/components/Carousel.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Carousel.ts#L8)
+Defined in: [src/components/Carousel.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Carousel.ts#L8)
 
 #### Parameters
 
@@ -1321,7 +1321,7 @@ Defined in: [src/components/Carousel.ts:8](https://github.com/shdwmtr/plugutil/b
 optional fnGetColumnWidth: (...unknown: any[]) => number;
 ```
 
-Defined in: [src/components/Carousel.ts:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Carousel.ts#L9)
+Defined in: [src/components/Carousel.ts:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Carousel.ts#L9)
 
 #### Parameters
 
@@ -1341,7 +1341,7 @@ Defined in: [src/components/Carousel.ts:9](https://github.com/shdwmtr/plugutil/b
 optional fnGetId: (id: number) => number;
 ```
 
-Defined in: [src/components/Carousel.ts:10](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Carousel.ts#L10)
+Defined in: [src/components/Carousel.ts:10](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Carousel.ts#L10)
 
 #### Parameters
 
@@ -1361,7 +1361,7 @@ Defined in: [src/components/Carousel.ts:10](https://github.com/shdwmtr/plugutil/
 optional fnItemRenderer: (id: number, ...unknown: any[]) => ReactNode;
 ```
 
-Defined in: [src/components/Carousel.ts:11](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Carousel.ts#L11)
+Defined in: [src/components/Carousel.ts:11](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Carousel.ts#L11)
 
 #### Parameters
 
@@ -1385,7 +1385,7 @@ Defined in: [src/components/Carousel.ts:11](https://github.com/shdwmtr/plugutil/
 optional fnUpdateArrows: (...unknown: any[]) => any;
 ```
 
-Defined in: [src/components/Carousel.ts:12](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Carousel.ts#L12)
+Defined in: [src/components/Carousel.ts:12](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Carousel.ts#L12)
 
 #### Parameters
 
@@ -1437,7 +1437,7 @@ HTMLAttributes.id
 optional initialColumn: number;
 ```
 
-Defined in: [src/components/Carousel.ts:13](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Carousel.ts#L13)
+Defined in: [src/components/Carousel.ts:13](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Carousel.ts#L13)
 
 ***
 
@@ -1611,7 +1611,7 @@ HTMLAttributes.lang
 optional name: string;
 ```
 
-Defined in: [src/components/Carousel.ts:19](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Carousel.ts#L19)
+Defined in: [src/components/Carousel.ts:19](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Carousel.ts#L19)
 
 ***
 
@@ -1621,7 +1621,7 @@ Defined in: [src/components/Carousel.ts:19](https://github.com/shdwmtr/plugutil/
 optional nHeight: number;
 ```
 
-Defined in: [src/components/Carousel.ts:14](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Carousel.ts#L14)
+Defined in: [src/components/Carousel.ts:14](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Carousel.ts#L14)
 
 ***
 
@@ -1631,7 +1631,7 @@ Defined in: [src/components/Carousel.ts:14](https://github.com/shdwmtr/plugutil/
 optional nIndexLeftmost: number;
 ```
 
-Defined in: [src/components/Carousel.ts:15](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Carousel.ts#L15)
+Defined in: [src/components/Carousel.ts:15](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Carousel.ts#L15)
 
 ***
 
@@ -1641,7 +1641,7 @@ Defined in: [src/components/Carousel.ts:15](https://github.com/shdwmtr/plugutil/
 optional nItemHeight: number;
 ```
 
-Defined in: [src/components/Carousel.ts:16](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Carousel.ts#L16)
+Defined in: [src/components/Carousel.ts:16](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Carousel.ts#L16)
 
 ***
 
@@ -1651,7 +1651,7 @@ Defined in: [src/components/Carousel.ts:16](https://github.com/shdwmtr/plugutil/
 optional nItemMarginX: number;
 ```
 
-Defined in: [src/components/Carousel.ts:17](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Carousel.ts#L17)
+Defined in: [src/components/Carousel.ts:17](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Carousel.ts#L17)
 
 ***
 
@@ -1661,7 +1661,7 @@ Defined in: [src/components/Carousel.ts:17](https://github.com/shdwmtr/plugutil/
 optional nNumItems: number;
 ```
 
-Defined in: [src/components/Carousel.ts:18](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Carousel.ts#L18)
+Defined in: [src/components/Carousel.ts:18](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Carousel.ts#L18)
 
 ***
 
@@ -4343,7 +4343,7 @@ HTMLAttributes.role
 optional scrollToAlignment: "center";
 ```
 
-Defined in: [src/components/Carousel.ts:20](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Carousel.ts#L20)
+Defined in: [src/components/Carousel.ts:20](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Carousel.ts#L20)
 
 ***
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/ClassModule.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/ClassModule.md
@@ -4,7 +4,7 @@
 
 # Interface: ClassModule
 
-Defined in: [src/class-mapper.ts:3](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/class-mapper.ts#L3)
+Defined in: [src/class-mapper.ts:3](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/class-mapper.ts#L3)
 
 ## Indexable
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/ColorPickerModalProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/ColorPickerModalProps.md
@@ -4,7 +4,7 @@
 
 # Interface: ColorPickerModalProps
 
-Defined in: [src/custom-components/ColorPickerModal.tsx:6](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/custom-components/ColorPickerModal.tsx#L6)
+Defined in: [src/custom-components/ColorPickerModal.tsx:6](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/custom-components/ColorPickerModal.tsx#L6)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/custom-components/ColorPickerModal.tsx:6](https://github.com/sh
 closeModal: () => void;
 ```
 
-Defined in: [src/custom-components/ColorPickerModal.tsx:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/custom-components/ColorPickerModal.tsx#L7)
+Defined in: [src/custom-components/ColorPickerModal.tsx:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/custom-components/ColorPickerModal.tsx#L7)
 
 #### Returns
 
@@ -28,7 +28,7 @@ Defined in: [src/custom-components/ColorPickerModal.tsx:7](https://github.com/sh
 optional defaultA: number;
 ```
 
-Defined in: [src/custom-components/ColorPickerModal.tsx:13](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/custom-components/ColorPickerModal.tsx#L13)
+Defined in: [src/custom-components/ColorPickerModal.tsx:13](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/custom-components/ColorPickerModal.tsx#L13)
 
 ***
 
@@ -38,7 +38,7 @@ Defined in: [src/custom-components/ColorPickerModal.tsx:13](https://github.com/s
 optional defaultH: number;
 ```
 
-Defined in: [src/custom-components/ColorPickerModal.tsx:10](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/custom-components/ColorPickerModal.tsx#L10)
+Defined in: [src/custom-components/ColorPickerModal.tsx:10](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/custom-components/ColorPickerModal.tsx#L10)
 
 ***
 
@@ -48,7 +48,7 @@ Defined in: [src/custom-components/ColorPickerModal.tsx:10](https://github.com/s
 optional defaultL: number;
 ```
 
-Defined in: [src/custom-components/ColorPickerModal.tsx:12](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/custom-components/ColorPickerModal.tsx#L12)
+Defined in: [src/custom-components/ColorPickerModal.tsx:12](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/custom-components/ColorPickerModal.tsx#L12)
 
 ***
 
@@ -58,7 +58,7 @@ Defined in: [src/custom-components/ColorPickerModal.tsx:12](https://github.com/s
 optional defaultS: number;
 ```
 
-Defined in: [src/custom-components/ColorPickerModal.tsx:11](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/custom-components/ColorPickerModal.tsx#L11)
+Defined in: [src/custom-components/ColorPickerModal.tsx:11](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/custom-components/ColorPickerModal.tsx#L11)
 
 ***
 
@@ -68,7 +68,7 @@ Defined in: [src/custom-components/ColorPickerModal.tsx:11](https://github.com/s
 optional title: string;
 ```
 
-Defined in: [src/custom-components/ColorPickerModal.tsx:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/custom-components/ColorPickerModal.tsx#L9)
+Defined in: [src/custom-components/ColorPickerModal.tsx:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/custom-components/ColorPickerModal.tsx#L9)
 
 ## Methods
 
@@ -78,7 +78,7 @@ Defined in: [src/custom-components/ColorPickerModal.tsx:9](https://github.com/sh
 optional onConfirm(HSLString: string): any
 ```
 
-Defined in: [src/custom-components/ColorPickerModal.tsx:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/custom-components/ColorPickerModal.tsx#L8)
+Defined in: [src/custom-components/ColorPickerModal.tsx:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/custom-components/ColorPickerModal.tsx#L8)
 
 #### Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/ConfirmModalProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/ConfirmModalProps.md
@@ -4,7 +4,7 @@
 
 # Interface: ConfirmModalProps
 
-Defined in: [src/components/Modal.tsx:76](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L76)
+Defined in: [src/components/Modal.tsx:76](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L76)
 
 ## Extends
 
@@ -18,7 +18,7 @@ Defined in: [src/components/Modal.tsx:76](https://github.com/shdwmtr/plugutil/bl
 optional bAlertDialog: boolean;
 ```
 
-Defined in: [src/components/Modal.tsx:83](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L83)
+Defined in: [src/components/Modal.tsx:83](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L83)
 
 ***
 
@@ -28,7 +28,7 @@ Defined in: [src/components/Modal.tsx:83](https://github.com/shdwmtr/plugutil/bl
 optional bAllowFullSize: boolean;
 ```
 
-Defined in: [src/components/Modal.tsx:68](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L68)
+Defined in: [src/components/Modal.tsx:68](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L68)
 
 #### Inherited from
 
@@ -42,7 +42,7 @@ Defined in: [src/components/Modal.tsx:68](https://github.com/shdwmtr/plugutil/bl
 optional bCancelDisabled: boolean;
 ```
 
-Defined in: [src/components/Modal.tsx:73](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L73)
+Defined in: [src/components/Modal.tsx:73](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L73)
 
 #### Inherited from
 
@@ -56,7 +56,7 @@ Defined in: [src/components/Modal.tsx:73](https://github.com/shdwmtr/plugutil/bl
 optional bDestructiveWarning: boolean;
 ```
 
-Defined in: [src/components/Modal.tsx:69](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L69)
+Defined in: [src/components/Modal.tsx:69](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L69)
 
 #### Inherited from
 
@@ -70,7 +70,7 @@ Defined in: [src/components/Modal.tsx:69](https://github.com/shdwmtr/plugutil/bl
 optional bDisableBackgroundDismiss: boolean;
 ```
 
-Defined in: [src/components/Modal.tsx:70](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L70)
+Defined in: [src/components/Modal.tsx:70](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L70)
 
 #### Inherited from
 
@@ -84,7 +84,7 @@ Defined in: [src/components/Modal.tsx:70](https://github.com/shdwmtr/plugutil/bl
 optional bHideCloseIcon: boolean;
 ```
 
-Defined in: [src/components/Modal.tsx:71](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L71)
+Defined in: [src/components/Modal.tsx:71](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L71)
 
 #### Inherited from
 
@@ -98,7 +98,7 @@ Defined in: [src/components/Modal.tsx:71](https://github.com/shdwmtr/plugutil/bl
 optional bMiddleDisabled: boolean;
 ```
 
-Defined in: [src/components/Modal.tsx:84](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L84)
+Defined in: [src/components/Modal.tsx:84](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L84)
 
 ***
 
@@ -108,7 +108,7 @@ Defined in: [src/components/Modal.tsx:84](https://github.com/shdwmtr/plugutil/bl
 optional bOKDisabled: boolean;
 ```
 
-Defined in: [src/components/Modal.tsx:72](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L72)
+Defined in: [src/components/Modal.tsx:72](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L72)
 
 #### Inherited from
 
@@ -122,7 +122,7 @@ Defined in: [src/components/Modal.tsx:72](https://github.com/shdwmtr/plugutil/bl
 optional children: ReactNode;
 ```
 
-Defined in: [src/components/Modal.tsx:61](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L61)
+Defined in: [src/components/Modal.tsx:61](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L61)
 
 #### Inherited from
 
@@ -136,7 +136,7 @@ Defined in: [src/components/Modal.tsx:61](https://github.com/shdwmtr/plugutil/bl
 optional className: string;
 ```
 
-Defined in: [src/components/Modal.tsx:66](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L66)
+Defined in: [src/components/Modal.tsx:66](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L66)
 
 #### Inherited from
 
@@ -150,7 +150,7 @@ Defined in: [src/components/Modal.tsx:66](https://github.com/shdwmtr/plugutil/bl
 optional modalClassName: string;
 ```
 
-Defined in: [src/components/Modal.tsx:67](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L67)
+Defined in: [src/components/Modal.tsx:67](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L67)
 
 #### Inherited from
 
@@ -164,7 +164,7 @@ Defined in: [src/components/Modal.tsx:67](https://github.com/shdwmtr/plugutil/bl
 optional strCancelButtonText: ReactNode;
 ```
 
-Defined in: [src/components/Modal.tsx:81](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L81)
+Defined in: [src/components/Modal.tsx:81](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L81)
 
 ***
 
@@ -174,7 +174,7 @@ Defined in: [src/components/Modal.tsx:81](https://github.com/shdwmtr/plugutil/bl
 optional strDescription: ReactNode;
 ```
 
-Defined in: [src/components/Modal.tsx:79](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L79)
+Defined in: [src/components/Modal.tsx:79](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L79)
 
 ***
 
@@ -184,7 +184,7 @@ Defined in: [src/components/Modal.tsx:79](https://github.com/shdwmtr/plugutil/bl
 optional strMiddleButtonText: ReactNode;
 ```
 
-Defined in: [src/components/Modal.tsx:82](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L82)
+Defined in: [src/components/Modal.tsx:82](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L82)
 
 ***
 
@@ -194,7 +194,7 @@ Defined in: [src/components/Modal.tsx:82](https://github.com/shdwmtr/plugutil/bl
 optional strOKButtonText: ReactNode;
 ```
 
-Defined in: [src/components/Modal.tsx:80](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L80)
+Defined in: [src/components/Modal.tsx:80](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L80)
 
 ***
 
@@ -204,7 +204,7 @@ Defined in: [src/components/Modal.tsx:80](https://github.com/shdwmtr/plugutil/bl
 optional strTitle: ReactNode;
 ```
 
-Defined in: [src/components/Modal.tsx:78](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L78)
+Defined in: [src/components/Modal.tsx:78](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L78)
 
 ## Methods
 
@@ -214,7 +214,7 @@ Defined in: [src/components/Modal.tsx:78](https://github.com/shdwmtr/plugutil/bl
 optional closeModal(): void
 ```
 
-Defined in: [src/components/Modal.tsx:63](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L63)
+Defined in: [src/components/Modal.tsx:63](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L63)
 
 #### Returns
 
@@ -232,7 +232,7 @@ Defined in: [src/components/Modal.tsx:63](https://github.com/shdwmtr/plugutil/bl
 optional onCancel(): void
 ```
 
-Defined in: [src/components/Modal.tsx:62](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L62)
+Defined in: [src/components/Modal.tsx:62](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L62)
 
 #### Returns
 
@@ -250,7 +250,7 @@ Defined in: [src/components/Modal.tsx:62](https://github.com/shdwmtr/plugutil/bl
 optional onEscKeypress(): void
 ```
 
-Defined in: [src/components/Modal.tsx:65](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L65)
+Defined in: [src/components/Modal.tsx:65](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L65)
 
 #### Returns
 
@@ -268,7 +268,7 @@ Defined in: [src/components/Modal.tsx:65](https://github.com/shdwmtr/plugutil/bl
 optional onMiddleButton(): void
 ```
 
-Defined in: [src/components/Modal.tsx:77](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L77)
+Defined in: [src/components/Modal.tsx:77](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L77)
 
 #### Returns
 
@@ -282,7 +282,7 @@ Defined in: [src/components/Modal.tsx:77](https://github.com/shdwmtr/plugutil/bl
 optional onOK(): void
 ```
 
-Defined in: [src/components/Modal.tsx:64](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L64)
+Defined in: [src/components/Modal.tsx:64](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L64)
 
 #### Returns
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/ControlsListProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/ControlsListProps.md
@@ -4,7 +4,7 @@
 
 # Interface: ControlsListProps
 
-Defined in: [src/components/ControlsList.ts:5](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ControlsList.ts#L5)
+Defined in: [src/components/ControlsList.ts:5](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ControlsList.ts#L5)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/components/ControlsList.ts:5](https://github.com/shdwmtr/plugut
 optional alignItems: "center" | "left" | "right";
 ```
 
-Defined in: [src/components/ControlsList.ts:6](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ControlsList.ts#L6)
+Defined in: [src/components/ControlsList.ts:6](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ControlsList.ts#L6)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/components/ControlsList.ts:6](https://github.com/shdwmtr/plugut
 optional children: ReactNode;
 ```
 
-Defined in: [src/components/ControlsList.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ControlsList.ts#L8)
+Defined in: [src/components/ControlsList.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ControlsList.ts#L8)
 
 ***
 
@@ -34,4 +34,4 @@ Defined in: [src/components/ControlsList.ts:8](https://github.com/shdwmtr/plugut
 optional spacing: "standard" | "extra";
 ```
 
-Defined in: [src/components/ControlsList.ts:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ControlsList.ts#L7)
+Defined in: [src/components/ControlsList.ts:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ControlsList.ts#L7)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/DialogButtonProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/DialogButtonProps.md
@@ -4,7 +4,7 @@
 
 # Interface: DialogButtonProps
 
-Defined in: [src/components/Dialog.ts:12](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L12)
+Defined in: [src/components/Dialog.ts:12](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L12)
 
 ## Extends
 
@@ -22,7 +22,7 @@ Defined in: [src/components/Dialog.ts:12](https://github.com/shdwmtr/plugutil/bl
 optional actionDescriptionMap: ActionDescriptionMap;
 ```
 
-Defined in: [src/components/FooterLegend.ts:53](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L53)
+Defined in: [src/components/FooterLegend.ts:53](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L53)
 
 #### Inherited from
 
@@ -36,7 +36,7 @@ Defined in: [src/components/FooterLegend.ts:53](https://github.com/shdwmtr/plugu
 optional children: ReactNode;
 ```
 
-Defined in: [src/components/Dialog.ts:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L9)
+Defined in: [src/components/Dialog.ts:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L9)
 
 #### Inherited from
 
@@ -50,7 +50,7 @@ Defined in: [src/components/Dialog.ts:9](https://github.com/shdwmtr/plugutil/blo
 optional className: string;
 ```
 
-Defined in: [src/components/Dialog.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L8)
+Defined in: [src/components/Dialog.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L8)
 
 #### Inherited from
 
@@ -64,7 +64,7 @@ Defined in: [src/components/Dialog.ts:8](https://github.com/shdwmtr/plugutil/blo
 optional disabled: boolean;
 ```
 
-Defined in: [src/components/Dialog.ts:30](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L30)
+Defined in: [src/components/Dialog.ts:30](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L30)
 
 Disables the button - assigned `on*` methods will not be invoked if clicked.
 
@@ -85,7 +85,7 @@ focusable.
 optional focusable: boolean;
 ```
 
-Defined in: [src/components/Dialog.ts:40](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L40)
+Defined in: [src/components/Dialog.ts:40](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L40)
 
 Enables/disables the navigation based focus on button - you won't be able to navigate to
 it via the gamepad or keyboard.
@@ -117,7 +117,7 @@ Defined in: node\_modules/@types/react/index.d.ts:137
 optional noFocusRing: boolean;
 ```
 
-Defined in: [src/components/Dialog.ts:19](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L19)
+Defined in: [src/components/Dialog.ts:19](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L19)
 
 Enables/disables the focus around the button.
 
@@ -133,7 +133,7 @@ Default value depends on context, so setting it to `false` will enable it.
 optional onButtonDown: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:59](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L59)
+Defined in: [src/components/FooterLegend.ts:59](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L59)
 
 #### Parameters
 
@@ -157,7 +157,7 @@ Defined in: [src/components/FooterLegend.ts:59](https://github.com/shdwmtr/plugu
 optional onButtonUp: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:60](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L60)
+Defined in: [src/components/FooterLegend.ts:60](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L60)
 
 #### Parameters
 
@@ -181,7 +181,7 @@ Defined in: [src/components/FooterLegend.ts:60](https://github.com/shdwmtr/plugu
 optional onCancelActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:55](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L55)
+Defined in: [src/components/FooterLegend.ts:55](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L55)
 
 #### Inherited from
 
@@ -195,7 +195,7 @@ Defined in: [src/components/FooterLegend.ts:55](https://github.com/shdwmtr/plugu
 optional onCancelButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:62](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L62)
+Defined in: [src/components/FooterLegend.ts:62](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L62)
 
 #### Parameters
 
@@ -219,7 +219,7 @@ Defined in: [src/components/FooterLegend.ts:62](https://github.com/shdwmtr/plugu
 optional onGamepadBlur: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:67](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L67)
+Defined in: [src/components/FooterLegend.ts:67](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L67)
 
 #### Parameters
 
@@ -243,7 +243,7 @@ Defined in: [src/components/FooterLegend.ts:67](https://github.com/shdwmtr/plugu
 optional onGamepadDirection: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:65](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L65)
+Defined in: [src/components/FooterLegend.ts:65](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L65)
 
 #### Parameters
 
@@ -267,7 +267,7 @@ Defined in: [src/components/FooterLegend.ts:65](https://github.com/shdwmtr/plugu
 optional onGamepadFocus: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:66](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L66)
+Defined in: [src/components/FooterLegend.ts:66](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L66)
 
 #### Parameters
 
@@ -291,7 +291,7 @@ Defined in: [src/components/FooterLegend.ts:66](https://github.com/shdwmtr/plugu
 optional onMenuActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:58](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L58)
+Defined in: [src/components/FooterLegend.ts:58](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L58)
 
 #### Inherited from
 
@@ -305,7 +305,7 @@ Defined in: [src/components/FooterLegend.ts:58](https://github.com/shdwmtr/plugu
 optional onMenuButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:68](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L68)
+Defined in: [src/components/FooterLegend.ts:68](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L68)
 
 #### Parameters
 
@@ -329,7 +329,7 @@ Defined in: [src/components/FooterLegend.ts:68](https://github.com/shdwmtr/plugu
 optional onOKActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:54](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L54)
+Defined in: [src/components/FooterLegend.ts:54](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L54)
 
 #### Inherited from
 
@@ -343,7 +343,7 @@ Defined in: [src/components/FooterLegend.ts:54](https://github.com/shdwmtr/plugu
 optional onOKButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:61](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L61)
+Defined in: [src/components/FooterLegend.ts:61](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L61)
 
 #### Parameters
 
@@ -367,7 +367,7 @@ Defined in: [src/components/FooterLegend.ts:61](https://github.com/shdwmtr/plugu
 optional onOptionsActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:57](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L57)
+Defined in: [src/components/FooterLegend.ts:57](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L57)
 
 #### Inherited from
 
@@ -381,7 +381,7 @@ Defined in: [src/components/FooterLegend.ts:57](https://github.com/shdwmtr/plugu
 optional onOptionsButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:64](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L64)
+Defined in: [src/components/FooterLegend.ts:64](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L64)
 
 #### Parameters
 
@@ -405,7 +405,7 @@ Defined in: [src/components/FooterLegend.ts:64](https://github.com/shdwmtr/plugu
 optional onSecondaryActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:56](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L56)
+Defined in: [src/components/FooterLegend.ts:56](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L56)
 
 #### Inherited from
 
@@ -419,7 +419,7 @@ Defined in: [src/components/FooterLegend.ts:56](https://github.com/shdwmtr/plugu
 optional onSecondaryButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:63](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L63)
+Defined in: [src/components/FooterLegend.ts:63](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L63)
 
 #### Parameters
 
@@ -457,7 +457,7 @@ Defined in: node\_modules/@types/react/index.d.ts:140
 optional style: CSSProperties;
 ```
 
-Defined in: [src/components/Dialog.ts:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L7)
+Defined in: [src/components/Dialog.ts:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L7)
 
 #### Inherited from
 
@@ -471,7 +471,7 @@ Defined in: [src/components/Dialog.ts:7](https://github.com/shdwmtr/plugutil/blo
 optional onClick(e: MouseEvent): void
 ```
 
-Defined in: [src/components/Dialog.ts:42](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L42)
+Defined in: [src/components/Dialog.ts:42](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L42)
 
 #### Parameters
 
@@ -491,7 +491,7 @@ Defined in: [src/components/Dialog.ts:42](https://github.com/shdwmtr/plugutil/bl
 optional onMouseDown(e: MouseEvent): void
 ```
 
-Defined in: [src/components/Dialog.ts:46](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L46)
+Defined in: [src/components/Dialog.ts:46](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L46)
 
 #### Parameters
 
@@ -511,7 +511,7 @@ Defined in: [src/components/Dialog.ts:46](https://github.com/shdwmtr/plugutil/bl
 optional onMouseUp(e: MouseEvent): void
 ```
 
-Defined in: [src/components/Dialog.ts:47](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L47)
+Defined in: [src/components/Dialog.ts:47](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L47)
 
 #### Parameters
 
@@ -531,7 +531,7 @@ Defined in: [src/components/Dialog.ts:47](https://github.com/shdwmtr/plugutil/bl
 optional onPointerCancel(e: PointerEvent): void
 ```
 
-Defined in: [src/components/Dialog.ts:45](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L45)
+Defined in: [src/components/Dialog.ts:45](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L45)
 
 #### Parameters
 
@@ -551,7 +551,7 @@ Defined in: [src/components/Dialog.ts:45](https://github.com/shdwmtr/plugutil/bl
 optional onPointerDown(e: PointerEvent): void
 ```
 
-Defined in: [src/components/Dialog.ts:43](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L43)
+Defined in: [src/components/Dialog.ts:43](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L43)
 
 #### Parameters
 
@@ -571,7 +571,7 @@ Defined in: [src/components/Dialog.ts:43](https://github.com/shdwmtr/plugutil/bl
 optional onPointerUp(e: PointerEvent): void
 ```
 
-Defined in: [src/components/Dialog.ts:44](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L44)
+Defined in: [src/components/Dialog.ts:44](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L44)
 
 #### Parameters
 
@@ -591,7 +591,7 @@ Defined in: [src/components/Dialog.ts:44](https://github.com/shdwmtr/plugutil/bl
 optional onSubmit(e: SubmitEvent): void
 ```
 
-Defined in: [src/components/Dialog.ts:51](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L51)
+Defined in: [src/components/Dialog.ts:51](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L51)
 
 #### Parameters
 
@@ -611,7 +611,7 @@ Defined in: [src/components/Dialog.ts:51](https://github.com/shdwmtr/plugutil/bl
 optional onTouchCancel(e: TouchEvent): void
 ```
 
-Defined in: [src/components/Dialog.ts:50](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L50)
+Defined in: [src/components/Dialog.ts:50](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L50)
 
 #### Parameters
 
@@ -631,7 +631,7 @@ Defined in: [src/components/Dialog.ts:50](https://github.com/shdwmtr/plugutil/bl
 optional onTouchEnd(e: TouchEvent): void
 ```
 
-Defined in: [src/components/Dialog.ts:49](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L49)
+Defined in: [src/components/Dialog.ts:49](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L49)
 
 #### Parameters
 
@@ -651,7 +651,7 @@ Defined in: [src/components/Dialog.ts:49](https://github.com/shdwmtr/plugutil/bl
 optional onTouchStart(e: TouchEvent): void
 ```
 
-Defined in: [src/components/Dialog.ts:48](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L48)
+Defined in: [src/components/Dialog.ts:48](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L48)
 
 #### Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/DialogCheckboxProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/DialogCheckboxProps.md
@@ -4,7 +4,7 @@
 
 # Interface: DialogCheckboxProps
 
-Defined in: [src/components/DialogCheckbox.ts:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/DialogCheckbox.ts#L7)
+Defined in: [src/components/DialogCheckbox.ts:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/DialogCheckbox.ts#L7)
 
 ## Extends
 
@@ -18,7 +18,7 @@ Defined in: [src/components/DialogCheckbox.ts:7](https://github.com/shdwmtr/plug
 optional actionDescriptionMap: ActionDescriptionMap;
 ```
 
-Defined in: [src/components/FooterLegend.ts:53](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L53)
+Defined in: [src/components/FooterLegend.ts:53](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L53)
 
 #### Inherited from
 
@@ -32,7 +32,7 @@ Defined in: [src/components/FooterLegend.ts:53](https://github.com/shdwmtr/plugu
 optional bottomSeparator: "standard" | "thick" | "none";
 ```
 
-Defined in: [src/components/DialogCheckbox.ts:15](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/DialogCheckbox.ts#L15)
+Defined in: [src/components/DialogCheckbox.ts:15](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/DialogCheckbox.ts#L15)
 
 ***
 
@@ -42,7 +42,7 @@ Defined in: [src/components/DialogCheckbox.ts:15](https://github.com/shdwmtr/plu
 optional checked: boolean;
 ```
 
-Defined in: [src/components/DialogCheckbox.ts:17](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/DialogCheckbox.ts#L17)
+Defined in: [src/components/DialogCheckbox.ts:17](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/DialogCheckbox.ts#L17)
 
 ***
 
@@ -52,7 +52,7 @@ Defined in: [src/components/DialogCheckbox.ts:17](https://github.com/shdwmtr/plu
 optional children: ReactNode;
 ```
 
-Defined in: [src/components/Dialog.ts:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L9)
+Defined in: [src/components/Dialog.ts:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L9)
 
 #### Inherited from
 
@@ -66,7 +66,7 @@ Defined in: [src/components/Dialog.ts:9](https://github.com/shdwmtr/plugutil/blo
 optional className: string;
 ```
 
-Defined in: [src/components/Dialog.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L8)
+Defined in: [src/components/Dialog.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L8)
 
 #### Inherited from
 
@@ -80,7 +80,7 @@ Defined in: [src/components/Dialog.ts:8](https://github.com/shdwmtr/plugutil/blo
 optional color: string;
 ```
 
-Defined in: [src/components/DialogCheckbox.ts:13](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/DialogCheckbox.ts#L13)
+Defined in: [src/components/DialogCheckbox.ts:13](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/DialogCheckbox.ts#L13)
 
 ***
 
@@ -90,7 +90,7 @@ Defined in: [src/components/DialogCheckbox.ts:13](https://github.com/shdwmtr/plu
 optional controlled: boolean;
 ```
 
-Defined in: [src/components/DialogCheckbox.ts:16](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/DialogCheckbox.ts#L16)
+Defined in: [src/components/DialogCheckbox.ts:16](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/DialogCheckbox.ts#L16)
 
 ***
 
@@ -100,7 +100,7 @@ Defined in: [src/components/DialogCheckbox.ts:16](https://github.com/shdwmtr/plu
 optional description: ReactNode;
 ```
 
-Defined in: [src/components/DialogCheckbox.ts:10](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/DialogCheckbox.ts#L10)
+Defined in: [src/components/DialogCheckbox.ts:10](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/DialogCheckbox.ts#L10)
 
 ***
 
@@ -110,7 +110,7 @@ Defined in: [src/components/DialogCheckbox.ts:10](https://github.com/shdwmtr/plu
 optional disabled: boolean;
 ```
 
-Defined in: [src/components/DialogCheckbox.ts:11](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/DialogCheckbox.ts#L11)
+Defined in: [src/components/DialogCheckbox.ts:11](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/DialogCheckbox.ts#L11)
 
 ***
 
@@ -120,7 +120,7 @@ Defined in: [src/components/DialogCheckbox.ts:11](https://github.com/shdwmtr/plu
 optional highlightColor: string;
 ```
 
-Defined in: [src/components/DialogCheckbox.ts:14](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/DialogCheckbox.ts#L14)
+Defined in: [src/components/DialogCheckbox.ts:14](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/DialogCheckbox.ts#L14)
 
 ***
 
@@ -144,7 +144,7 @@ Defined in: node\_modules/@types/react/index.d.ts:137
 optional label: ReactNode;
 ```
 
-Defined in: [src/components/DialogCheckbox.ts:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/DialogCheckbox.ts#L9)
+Defined in: [src/components/DialogCheckbox.ts:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/DialogCheckbox.ts#L9)
 
 ***
 
@@ -154,7 +154,7 @@ Defined in: [src/components/DialogCheckbox.ts:9](https://github.com/shdwmtr/plug
 optional onButtonDown: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:59](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L59)
+Defined in: [src/components/FooterLegend.ts:59](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L59)
 
 #### Parameters
 
@@ -178,7 +178,7 @@ Defined in: [src/components/FooterLegend.ts:59](https://github.com/shdwmtr/plugu
 optional onButtonUp: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:60](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L60)
+Defined in: [src/components/FooterLegend.ts:60](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L60)
 
 #### Parameters
 
@@ -202,7 +202,7 @@ Defined in: [src/components/FooterLegend.ts:60](https://github.com/shdwmtr/plugu
 optional onCancelActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:55](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L55)
+Defined in: [src/components/FooterLegend.ts:55](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L55)
 
 #### Inherited from
 
@@ -216,7 +216,7 @@ Defined in: [src/components/FooterLegend.ts:55](https://github.com/shdwmtr/plugu
 optional onCancelButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:62](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L62)
+Defined in: [src/components/FooterLegend.ts:62](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L62)
 
 #### Parameters
 
@@ -240,7 +240,7 @@ Defined in: [src/components/FooterLegend.ts:62](https://github.com/shdwmtr/plugu
 optional onGamepadBlur: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:67](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L67)
+Defined in: [src/components/FooterLegend.ts:67](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L67)
 
 #### Parameters
 
@@ -264,7 +264,7 @@ Defined in: [src/components/FooterLegend.ts:67](https://github.com/shdwmtr/plugu
 optional onGamepadDirection: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:65](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L65)
+Defined in: [src/components/FooterLegend.ts:65](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L65)
 
 #### Parameters
 
@@ -288,7 +288,7 @@ Defined in: [src/components/FooterLegend.ts:65](https://github.com/shdwmtr/plugu
 optional onGamepadFocus: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:66](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L66)
+Defined in: [src/components/FooterLegend.ts:66](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L66)
 
 #### Parameters
 
@@ -312,7 +312,7 @@ Defined in: [src/components/FooterLegend.ts:66](https://github.com/shdwmtr/plugu
 optional onMenuActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:58](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L58)
+Defined in: [src/components/FooterLegend.ts:58](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L58)
 
 #### Inherited from
 
@@ -326,7 +326,7 @@ Defined in: [src/components/FooterLegend.ts:58](https://github.com/shdwmtr/plugu
 optional onMenuButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:68](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L68)
+Defined in: [src/components/FooterLegend.ts:68](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L68)
 
 #### Parameters
 
@@ -350,7 +350,7 @@ Defined in: [src/components/FooterLegend.ts:68](https://github.com/shdwmtr/plugu
 optional onOKActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:54](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L54)
+Defined in: [src/components/FooterLegend.ts:54](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L54)
 
 #### Inherited from
 
@@ -364,7 +364,7 @@ Defined in: [src/components/FooterLegend.ts:54](https://github.com/shdwmtr/plugu
 optional onOKButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:61](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L61)
+Defined in: [src/components/FooterLegend.ts:61](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L61)
 
 #### Parameters
 
@@ -388,7 +388,7 @@ Defined in: [src/components/FooterLegend.ts:61](https://github.com/shdwmtr/plugu
 optional onOptionsActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:57](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L57)
+Defined in: [src/components/FooterLegend.ts:57](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L57)
 
 #### Inherited from
 
@@ -402,7 +402,7 @@ Defined in: [src/components/FooterLegend.ts:57](https://github.com/shdwmtr/plugu
 optional onOptionsButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:64](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L64)
+Defined in: [src/components/FooterLegend.ts:64](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L64)
 
 #### Parameters
 
@@ -426,7 +426,7 @@ Defined in: [src/components/FooterLegend.ts:64](https://github.com/shdwmtr/plugu
 optional onSecondaryActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:56](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L56)
+Defined in: [src/components/FooterLegend.ts:56](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L56)
 
 #### Inherited from
 
@@ -440,7 +440,7 @@ Defined in: [src/components/FooterLegend.ts:56](https://github.com/shdwmtr/plugu
 optional onSecondaryButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:63](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L63)
+Defined in: [src/components/FooterLegend.ts:63](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L63)
 
 #### Parameters
 
@@ -478,7 +478,7 @@ Defined in: node\_modules/@types/react/index.d.ts:140
 optional style: CSSProperties;
 ```
 
-Defined in: [src/components/Dialog.ts:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L7)
+Defined in: [src/components/Dialog.ts:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L7)
 
 #### Inherited from
 
@@ -492,7 +492,7 @@ Defined in: [src/components/Dialog.ts:7](https://github.com/shdwmtr/plugutil/blo
 optional tooltip: string;
 ```
 
-Defined in: [src/components/DialogCheckbox.ts:12](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/DialogCheckbox.ts#L12)
+Defined in: [src/components/DialogCheckbox.ts:12](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/DialogCheckbox.ts#L12)
 
 ## Methods
 
@@ -502,7 +502,7 @@ Defined in: [src/components/DialogCheckbox.ts:12](https://github.com/shdwmtr/plu
 optional onChange(checked: boolean): void
 ```
 
-Defined in: [src/components/DialogCheckbox.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/DialogCheckbox.ts#L8)
+Defined in: [src/components/DialogCheckbox.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/DialogCheckbox.ts#L8)
 
 #### Parameters
 
@@ -522,7 +522,7 @@ Defined in: [src/components/DialogCheckbox.ts:8](https://github.com/shdwmtr/plug
 optional onClick(evt: Event): void
 ```
 
-Defined in: [src/components/DialogCheckbox.ts:18](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/DialogCheckbox.ts#L18)
+Defined in: [src/components/DialogCheckbox.ts:18](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/DialogCheckbox.ts#L18)
 
 #### Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/DialogCommonProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/DialogCommonProps.md
@@ -4,7 +4,7 @@
 
 # Interface: DialogCommonProps
 
-Defined in: [src/components/Dialog.ts:6](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L6)
+Defined in: [src/components/Dialog.ts:6](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L6)
 
 ## Extends
 
@@ -23,7 +23,7 @@ Defined in: [src/components/Dialog.ts:6](https://github.com/shdwmtr/plugutil/blo
 optional children: ReactNode;
 ```
 
-Defined in: [src/components/Dialog.ts:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L9)
+Defined in: [src/components/Dialog.ts:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L9)
 
 ***
 
@@ -33,7 +33,7 @@ Defined in: [src/components/Dialog.ts:9](https://github.com/shdwmtr/plugutil/blo
 optional className: string;
 ```
 
-Defined in: [src/components/Dialog.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L8)
+Defined in: [src/components/Dialog.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L8)
 
 ***
 
@@ -75,4 +75,4 @@ RefAttributes.ref
 optional style: CSSProperties;
 ```
 
-Defined in: [src/components/Dialog.ts:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dialog.ts#L7)
+Defined in: [src/components/Dialog.ts:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dialog.ts#L7)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/DropdownItemProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/DropdownItemProps.md
@@ -4,7 +4,7 @@
 
 # Interface: DropdownItemProps
 
-Defined in: [src/components/Dropdown.ts:47](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L47)
+Defined in: [src/components/Dropdown.ts:47](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L47)
 
 ## Extends
 
@@ -18,7 +18,7 @@ Defined in: [src/components/Dropdown.ts:47](https://github.com/shdwmtr/plugutil/
 optional bottomSeparator: "standard" | "thick" | "none";
 ```
 
-Defined in: [src/components/Item.ts:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L9)
+Defined in: [src/components/Item.ts:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L9)
 
 #### Inherited from
 
@@ -34,7 +34,7 @@ ItemProps.bottomSeparator
 optional children: ReactNode;
 ```
 
-Defined in: [src/components/Item.ts:6](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L6)
+Defined in: [src/components/Item.ts:6](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L6)
 
 #### Inherited from
 
@@ -50,7 +50,7 @@ ItemProps.children
 optional contextMenuPositionOptions: DropdownMenuPositionOptions;
 ```
 
-Defined in: [src/components/Dropdown.ts:35](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L35)
+Defined in: [src/components/Dropdown.ts:35](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L35)
 
 #### Inherited from
 
@@ -64,7 +64,7 @@ Defined in: [src/components/Dropdown.ts:35](https://github.com/shdwmtr/plugutil/
 optional description: ReactNode;
 ```
 
-Defined in: [src/components/Item.ts:5](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L5)
+Defined in: [src/components/Item.ts:5](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L5)
 
 #### Inherited from
 
@@ -80,7 +80,7 @@ ItemProps.description
 optional disabled: boolean;
 ```
 
-Defined in: [src/components/Dropdown.ts:31](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L31)
+Defined in: [src/components/Dropdown.ts:31](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L31)
 
 #### Inherited from
 
@@ -94,7 +94,7 @@ Defined in: [src/components/Dropdown.ts:31](https://github.com/shdwmtr/plugutil/
 optional focusable: boolean;
 ```
 
-Defined in: [src/components/Dropdown.ts:39](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L39)
+Defined in: [src/components/Dropdown.ts:39](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L39)
 
 #### Inherited from
 
@@ -108,7 +108,7 @@ Defined in: [src/components/Dropdown.ts:39](https://github.com/shdwmtr/plugutil/
 optional highlightOnFocus: boolean;
 ```
 
-Defined in: [src/components/Item.ts:12](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L12)
+Defined in: [src/components/Item.ts:12](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L12)
 
 #### Inherited from
 
@@ -124,7 +124,7 @@ ItemProps.highlightOnFocus
 optional icon: ReactNode;
 ```
 
-Defined in: [src/components/Item.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L8)
+Defined in: [src/components/Item.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L8)
 
 #### Inherited from
 
@@ -140,7 +140,7 @@ ItemProps.icon
 optional indentLevel: number;
 ```
 
-Defined in: [src/components/Item.ts:10](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L10)
+Defined in: [src/components/Item.ts:10](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L10)
 
 #### Inherited from
 
@@ -156,7 +156,7 @@ ItemProps.indentLevel
 optional label: ReactNode;
 ```
 
-Defined in: [src/components/Item.ts:4](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L4)
+Defined in: [src/components/Item.ts:4](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L4)
 
 #### Inherited from
 
@@ -172,7 +172,7 @@ ItemProps.label
 optional layout: "below" | "inline";
 ```
 
-Defined in: [src/components/Item.ts:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L7)
+Defined in: [src/components/Item.ts:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L7)
 
 #### Inherited from
 
@@ -188,7 +188,7 @@ ItemProps.layout
 optional menuLabel: string;
 ```
 
-Defined in: [src/components/Dropdown.ts:36](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L36)
+Defined in: [src/components/Dropdown.ts:36](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L36)
 
 #### Inherited from
 
@@ -202,7 +202,7 @@ Defined in: [src/components/Dropdown.ts:36](https://github.com/shdwmtr/plugutil/
 rgOptions: DropdownOption[];
 ```
 
-Defined in: [src/components/Dropdown.ts:29](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L29)
+Defined in: [src/components/Dropdown.ts:29](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L29)
 
 #### Inherited from
 
@@ -216,7 +216,7 @@ Defined in: [src/components/Dropdown.ts:29](https://github.com/shdwmtr/plugutil/
 selectedOption: any;
 ```
 
-Defined in: [src/components/Dropdown.ts:30](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L30)
+Defined in: [src/components/Dropdown.ts:30](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L30)
 
 #### Inherited from
 
@@ -230,7 +230,7 @@ Defined in: [src/components/Dropdown.ts:30](https://github.com/shdwmtr/plugutil/
 optional strDefaultLabel: string;
 ```
 
-Defined in: [src/components/Dropdown.ts:37](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L37)
+Defined in: [src/components/Dropdown.ts:37](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L37)
 
 #### Inherited from
 
@@ -244,7 +244,7 @@ Defined in: [src/components/Dropdown.ts:37](https://github.com/shdwmtr/plugutil/
 optional tooltip: string;
 ```
 
-Defined in: [src/components/Item.ts:11](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L11)
+Defined in: [src/components/Item.ts:11](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L11)
 
 #### Inherited from
 
@@ -260,7 +260,7 @@ ItemProps.tooltip
 optional onChange(data: SingleDropdownOption): void
 ```
 
-Defined in: [src/components/Dropdown.ts:34](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L34)
+Defined in: [src/components/Dropdown.ts:34](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L34)
 
 #### Parameters
 
@@ -284,7 +284,7 @@ Defined in: [src/components/Dropdown.ts:34](https://github.com/shdwmtr/plugutil/
 optional onMenuOpened(): void
 ```
 
-Defined in: [src/components/Dropdown.ts:33](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L33)
+Defined in: [src/components/Dropdown.ts:33](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L33)
 
 #### Returns
 
@@ -302,7 +302,7 @@ Defined in: [src/components/Dropdown.ts:33](https://github.com/shdwmtr/plugutil/
 optional onMenuWillOpen(showMenu: () => void): void
 ```
 
-Defined in: [src/components/Dropdown.ts:32](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L32)
+Defined in: [src/components/Dropdown.ts:32](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L32)
 
 #### Parameters
 
@@ -326,7 +326,7 @@ Defined in: [src/components/Dropdown.ts:32](https://github.com/shdwmtr/plugutil/
 optional renderButtonValue(element: ReactNode): ReactNode
 ```
 
-Defined in: [src/components/Dropdown.ts:38](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L38)
+Defined in: [src/components/Dropdown.ts:38](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L38)
 
 #### Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/DropdownMenuPositionOptions.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/DropdownMenuPositionOptions.md
@@ -4,7 +4,7 @@
 
 # Interface: DropdownMenuPositionOptions
 
-Defined in: [src/components/Dropdown.ts:23](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L23)
+Defined in: [src/components/Dropdown.ts:23](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L23)
 
 ## Indexable
 
@@ -20,4 +20,4 @@ Defined in: [src/components/Dropdown.ts:23](https://github.com/shdwmtr/plugutil/
 optional bMatchWidth: boolean;
 ```
 
-Defined in: [src/components/Dropdown.ts:25](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L25)
+Defined in: [src/components/Dropdown.ts:25](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L25)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/DropdownProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/DropdownProps.md
@@ -4,7 +4,7 @@
 
 # Interface: DropdownProps
 
-Defined in: [src/components/Dropdown.ts:28](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L28)
+Defined in: [src/components/Dropdown.ts:28](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L28)
 
 ## Extended by
 
@@ -18,7 +18,7 @@ Defined in: [src/components/Dropdown.ts:28](https://github.com/shdwmtr/plugutil/
 optional contextMenuPositionOptions: DropdownMenuPositionOptions;
 ```
 
-Defined in: [src/components/Dropdown.ts:35](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L35)
+Defined in: [src/components/Dropdown.ts:35](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L35)
 
 ***
 
@@ -28,7 +28,7 @@ Defined in: [src/components/Dropdown.ts:35](https://github.com/shdwmtr/plugutil/
 optional disabled: boolean;
 ```
 
-Defined in: [src/components/Dropdown.ts:31](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L31)
+Defined in: [src/components/Dropdown.ts:31](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L31)
 
 ***
 
@@ -38,7 +38,7 @@ Defined in: [src/components/Dropdown.ts:31](https://github.com/shdwmtr/plugutil/
 optional focusable: boolean;
 ```
 
-Defined in: [src/components/Dropdown.ts:39](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L39)
+Defined in: [src/components/Dropdown.ts:39](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L39)
 
 ***
 
@@ -48,7 +48,7 @@ Defined in: [src/components/Dropdown.ts:39](https://github.com/shdwmtr/plugutil/
 optional menuLabel: string;
 ```
 
-Defined in: [src/components/Dropdown.ts:36](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L36)
+Defined in: [src/components/Dropdown.ts:36](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L36)
 
 ***
 
@@ -58,7 +58,7 @@ Defined in: [src/components/Dropdown.ts:36](https://github.com/shdwmtr/plugutil/
 rgOptions: DropdownOption[];
 ```
 
-Defined in: [src/components/Dropdown.ts:29](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L29)
+Defined in: [src/components/Dropdown.ts:29](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L29)
 
 ***
 
@@ -68,7 +68,7 @@ Defined in: [src/components/Dropdown.ts:29](https://github.com/shdwmtr/plugutil/
 selectedOption: any;
 ```
 
-Defined in: [src/components/Dropdown.ts:30](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L30)
+Defined in: [src/components/Dropdown.ts:30](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L30)
 
 ***
 
@@ -78,7 +78,7 @@ Defined in: [src/components/Dropdown.ts:30](https://github.com/shdwmtr/plugutil/
 optional strDefaultLabel: string;
 ```
 
-Defined in: [src/components/Dropdown.ts:37](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L37)
+Defined in: [src/components/Dropdown.ts:37](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L37)
 
 ## Methods
 
@@ -88,7 +88,7 @@ Defined in: [src/components/Dropdown.ts:37](https://github.com/shdwmtr/plugutil/
 optional onChange(data: SingleDropdownOption): void
 ```
 
-Defined in: [src/components/Dropdown.ts:34](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L34)
+Defined in: [src/components/Dropdown.ts:34](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L34)
 
 #### Parameters
 
@@ -108,7 +108,7 @@ Defined in: [src/components/Dropdown.ts:34](https://github.com/shdwmtr/plugutil/
 optional onMenuOpened(): void
 ```
 
-Defined in: [src/components/Dropdown.ts:33](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L33)
+Defined in: [src/components/Dropdown.ts:33](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L33)
 
 #### Returns
 
@@ -122,7 +122,7 @@ Defined in: [src/components/Dropdown.ts:33](https://github.com/shdwmtr/plugutil/
 optional onMenuWillOpen(showMenu: () => void): void
 ```
 
-Defined in: [src/components/Dropdown.ts:32](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L32)
+Defined in: [src/components/Dropdown.ts:32](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L32)
 
 #### Parameters
 
@@ -142,7 +142,7 @@ Defined in: [src/components/Dropdown.ts:32](https://github.com/shdwmtr/plugutil/
 optional renderButtonValue(element: ReactNode): ReactNode
 ```
 
-Defined in: [src/components/Dropdown.ts:38](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L38)
+Defined in: [src/components/Dropdown.ts:38](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L38)
 
 #### Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/FieldProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/FieldProps.md
@@ -4,7 +4,7 @@
 
 # Interface: FieldProps
 
-Defined in: [src/components/Field.ts:6](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Field.ts#L6)
+Defined in: [src/components/Field.ts:6](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Field.ts#L6)
 
 ## Extends
 
@@ -18,7 +18,7 @@ Defined in: [src/components/Field.ts:6](https://github.com/shdwmtr/plugutil/blob
 optional actionDescriptionMap: ActionDescriptionMap;
 ```
 
-Defined in: [src/components/FooterLegend.ts:53](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L53)
+Defined in: [src/components/FooterLegend.ts:53](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L53)
 
 #### Inherited from
 
@@ -32,7 +32,7 @@ Defined in: [src/components/FooterLegend.ts:53](https://github.com/shdwmtr/plugu
 optional bottomSeparator: "standard" | "thick" | "none";
 ```
 
-Defined in: [src/components/Field.ts:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Field.ts#L9)
+Defined in: [src/components/Field.ts:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Field.ts#L9)
 
 ***
 
@@ -42,7 +42,7 @@ Defined in: [src/components/Field.ts:9](https://github.com/shdwmtr/plugutil/blob
 optional children: ReactNode;
 ```
 
-Defined in: [src/components/Field.ts:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Field.ts#L7)
+Defined in: [src/components/Field.ts:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Field.ts#L7)
 
 ***
 
@@ -52,7 +52,7 @@ Defined in: [src/components/Field.ts:7](https://github.com/shdwmtr/plugutil/blob
 optional childrenContainerWidth: "min" | "max" | "fixed";
 ```
 
-Defined in: [src/components/Field.ts:15](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Field.ts#L15)
+Defined in: [src/components/Field.ts:15](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Field.ts#L15)
 
 ***
 
@@ -62,7 +62,7 @@ Defined in: [src/components/Field.ts:15](https://github.com/shdwmtr/plugutil/blo
 optional childrenLayout: "below" | "inline";
 ```
 
-Defined in: [src/components/Field.ts:14](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Field.ts#L14)
+Defined in: [src/components/Field.ts:14](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Field.ts#L14)
 
 ***
 
@@ -72,7 +72,7 @@ Defined in: [src/components/Field.ts:14](https://github.com/shdwmtr/plugutil/blo
 optional className: string;
 ```
 
-Defined in: [src/components/Field.ts:18](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Field.ts#L18)
+Defined in: [src/components/Field.ts:18](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Field.ts#L18)
 
 ***
 
@@ -82,7 +82,7 @@ Defined in: [src/components/Field.ts:18](https://github.com/shdwmtr/plugutil/blo
 optional description: ReactNode;
 ```
 
-Defined in: [src/components/Field.ts:10](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Field.ts#L10)
+Defined in: [src/components/Field.ts:10](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Field.ts#L10)
 
 ***
 
@@ -92,7 +92,7 @@ Defined in: [src/components/Field.ts:10](https://github.com/shdwmtr/plugutil/blo
 optional disabled: boolean;
 ```
 
-Defined in: [src/components/Field.ts:11](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Field.ts#L11)
+Defined in: [src/components/Field.ts:11](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Field.ts#L11)
 
 ***
 
@@ -102,7 +102,7 @@ Defined in: [src/components/Field.ts:11](https://github.com/shdwmtr/plugutil/blo
 optional focusable: boolean;
 ```
 
-Defined in: [src/components/Field.ts:22](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Field.ts#L22)
+Defined in: [src/components/Field.ts:22](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Field.ts#L22)
 
 ***
 
@@ -112,7 +112,7 @@ Defined in: [src/components/Field.ts:22](https://github.com/shdwmtr/plugutil/blo
 optional highlightOnFocus: boolean;
 ```
 
-Defined in: [src/components/Field.ts:19](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Field.ts#L19)
+Defined in: [src/components/Field.ts:19](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Field.ts#L19)
 
 ***
 
@@ -122,7 +122,7 @@ Defined in: [src/components/Field.ts:19](https://github.com/shdwmtr/plugutil/blo
 optional icon: ReactNode;
 ```
 
-Defined in: [src/components/Field.ts:12](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Field.ts#L12)
+Defined in: [src/components/Field.ts:12](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Field.ts#L12)
 
 ***
 
@@ -132,7 +132,7 @@ Defined in: [src/components/Field.ts:12](https://github.com/shdwmtr/plugutil/blo
 optional indentLevel: number;
 ```
 
-Defined in: [src/components/Field.ts:20](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Field.ts#L20)
+Defined in: [src/components/Field.ts:20](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Field.ts#L20)
 
 ***
 
@@ -142,7 +142,7 @@ Defined in: [src/components/Field.ts:20](https://github.com/shdwmtr/plugutil/blo
 optional inlineWrap: "keep-inline" | "shift-children-below";
 ```
 
-Defined in: [src/components/Field.ts:13](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Field.ts#L13)
+Defined in: [src/components/Field.ts:13](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Field.ts#L13)
 
 ***
 
@@ -152,7 +152,7 @@ Defined in: [src/components/Field.ts:13](https://github.com/shdwmtr/plugutil/blo
 optional label: ReactNode;
 ```
 
-Defined in: [src/components/Field.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Field.ts#L8)
+Defined in: [src/components/Field.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Field.ts#L8)
 
 ***
 
@@ -162,7 +162,7 @@ Defined in: [src/components/Field.ts:8](https://github.com/shdwmtr/plugutil/blob
 optional onActivate: (e: MouseEvent | CustomEvent) => void;
 ```
 
-Defined in: [src/components/Field.ts:23](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Field.ts#L23)
+Defined in: [src/components/Field.ts:23](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Field.ts#L23)
 
 #### Parameters
 
@@ -182,7 +182,7 @@ Defined in: [src/components/Field.ts:23](https://github.com/shdwmtr/plugutil/blo
 optional onButtonDown: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:59](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L59)
+Defined in: [src/components/FooterLegend.ts:59](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L59)
 
 #### Parameters
 
@@ -206,7 +206,7 @@ Defined in: [src/components/FooterLegend.ts:59](https://github.com/shdwmtr/plugu
 optional onButtonUp: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:60](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L60)
+Defined in: [src/components/FooterLegend.ts:60](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L60)
 
 #### Parameters
 
@@ -230,7 +230,7 @@ Defined in: [src/components/FooterLegend.ts:60](https://github.com/shdwmtr/plugu
 optional onCancelActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:55](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L55)
+Defined in: [src/components/FooterLegend.ts:55](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L55)
 
 #### Inherited from
 
@@ -244,7 +244,7 @@ Defined in: [src/components/FooterLegend.ts:55](https://github.com/shdwmtr/plugu
 optional onCancelButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:62](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L62)
+Defined in: [src/components/FooterLegend.ts:62](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L62)
 
 #### Parameters
 
@@ -268,7 +268,7 @@ Defined in: [src/components/FooterLegend.ts:62](https://github.com/shdwmtr/plugu
 optional onClick: (e: MouseEvent | CustomEvent) => void;
 ```
 
-Defined in: [src/components/Field.ts:24](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Field.ts#L24)
+Defined in: [src/components/Field.ts:24](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Field.ts#L24)
 
 #### Parameters
 
@@ -288,7 +288,7 @@ Defined in: [src/components/Field.ts:24](https://github.com/shdwmtr/plugutil/blo
 optional onGamepadBlur: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:67](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L67)
+Defined in: [src/components/FooterLegend.ts:67](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L67)
 
 #### Parameters
 
@@ -312,7 +312,7 @@ Defined in: [src/components/FooterLegend.ts:67](https://github.com/shdwmtr/plugu
 optional onGamepadDirection: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:65](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L65)
+Defined in: [src/components/FooterLegend.ts:65](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L65)
 
 #### Parameters
 
@@ -336,7 +336,7 @@ Defined in: [src/components/FooterLegend.ts:65](https://github.com/shdwmtr/plugu
 optional onGamepadFocus: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:66](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L66)
+Defined in: [src/components/FooterLegend.ts:66](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L66)
 
 #### Parameters
 
@@ -360,7 +360,7 @@ Defined in: [src/components/FooterLegend.ts:66](https://github.com/shdwmtr/plugu
 optional onMenuActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:58](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L58)
+Defined in: [src/components/FooterLegend.ts:58](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L58)
 
 #### Inherited from
 
@@ -374,7 +374,7 @@ Defined in: [src/components/FooterLegend.ts:58](https://github.com/shdwmtr/plugu
 optional onMenuButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:68](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L68)
+Defined in: [src/components/FooterLegend.ts:68](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L68)
 
 #### Parameters
 
@@ -398,7 +398,7 @@ Defined in: [src/components/FooterLegend.ts:68](https://github.com/shdwmtr/plugu
 optional onOKActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:54](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L54)
+Defined in: [src/components/FooterLegend.ts:54](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L54)
 
 #### Inherited from
 
@@ -412,7 +412,7 @@ Defined in: [src/components/FooterLegend.ts:54](https://github.com/shdwmtr/plugu
 optional onOKButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:61](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L61)
+Defined in: [src/components/FooterLegend.ts:61](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L61)
 
 #### Parameters
 
@@ -436,7 +436,7 @@ Defined in: [src/components/FooterLegend.ts:61](https://github.com/shdwmtr/plugu
 optional onOptionsActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:57](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L57)
+Defined in: [src/components/FooterLegend.ts:57](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L57)
 
 #### Inherited from
 
@@ -450,7 +450,7 @@ Defined in: [src/components/FooterLegend.ts:57](https://github.com/shdwmtr/plugu
 optional onOptionsButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:64](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L64)
+Defined in: [src/components/FooterLegend.ts:64](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L64)
 
 #### Parameters
 
@@ -474,7 +474,7 @@ Defined in: [src/components/FooterLegend.ts:64](https://github.com/shdwmtr/plugu
 optional onSecondaryActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:56](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L56)
+Defined in: [src/components/FooterLegend.ts:56](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L56)
 
 #### Inherited from
 
@@ -488,7 +488,7 @@ Defined in: [src/components/FooterLegend.ts:56](https://github.com/shdwmtr/plugu
 optional onSecondaryButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:63](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L63)
+Defined in: [src/components/FooterLegend.ts:63](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L63)
 
 #### Parameters
 
@@ -512,7 +512,7 @@ Defined in: [src/components/FooterLegend.ts:63](https://github.com/shdwmtr/plugu
 optional padding: "standard" | "none" | "compact";
 ```
 
-Defined in: [src/components/Field.ts:17](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Field.ts#L17)
+Defined in: [src/components/Field.ts:17](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Field.ts#L17)
 
 ***
 
@@ -522,7 +522,7 @@ Defined in: [src/components/Field.ts:17](https://github.com/shdwmtr/plugutil/blo
 optional spacingBetweenLabelAndChild: "none";
 ```
 
-Defined in: [src/components/Field.ts:16](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Field.ts#L16)
+Defined in: [src/components/Field.ts:16](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Field.ts#L16)
 
 ***
 
@@ -532,4 +532,4 @@ Defined in: [src/components/Field.ts:16](https://github.com/shdwmtr/plugutil/blo
 optional verticalAlignment: "none" | "center";
 ```
 
-Defined in: [src/components/Field.ts:21](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Field.ts#L21)
+Defined in: [src/components/Field.ts:21](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Field.ts#L21)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/FocusRingProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/FocusRingProps.md
@@ -4,7 +4,7 @@
 
 # Interface: FocusRingProps
 
-Defined in: [src/components/FocusRing.ts:5](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FocusRing.ts#L5)
+Defined in: [src/components/FocusRing.ts:5](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FocusRing.ts#L5)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/components/FocusRing.ts:5](https://github.com/shdwmtr/plugutil/
 optional children: ReactNode;
 ```
 
-Defined in: [src/components/FocusRing.ts:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FocusRing.ts#L9)
+Defined in: [src/components/FocusRing.ts:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FocusRing.ts#L9)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/components/FocusRing.ts:9](https://github.com/shdwmtr/plugutil/
 optional className: string;
 ```
 
-Defined in: [src/components/FocusRing.ts:6](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FocusRing.ts#L6)
+Defined in: [src/components/FocusRing.ts:6](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FocusRing.ts#L6)
 
 ***
 
@@ -34,7 +34,7 @@ Defined in: [src/components/FocusRing.ts:6](https://github.com/shdwmtr/plugutil/
 optional NavigationManager: any;
 ```
 
-Defined in: [src/components/FocusRing.ts:10](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FocusRing.ts#L10)
+Defined in: [src/components/FocusRing.ts:10](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FocusRing.ts#L10)
 
 ***
 
@@ -44,7 +44,7 @@ Defined in: [src/components/FocusRing.ts:10](https://github.com/shdwmtr/plugutil
 optional render: ElementType;
 ```
 
-Defined in: [src/components/FocusRing.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FocusRing.ts#L8)
+Defined in: [src/components/FocusRing.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FocusRing.ts#L8)
 
 ***
 
@@ -54,4 +54,4 @@ Defined in: [src/components/FocusRing.ts:8](https://github.com/shdwmtr/plugutil/
 optional rootClassName: string;
 ```
 
-Defined in: [src/components/FocusRing.ts:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FocusRing.ts#L7)
+Defined in: [src/components/FocusRing.ts:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FocusRing.ts#L7)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/FocusableProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/FocusableProps.md
@@ -4,7 +4,7 @@
 
 # Interface: FocusableProps
 
-Defined in: [src/components/Focusable.ts:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Focusable.ts#L7)
+Defined in: [src/components/Focusable.ts:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Focusable.ts#L7)
 
 ## Extends
 
@@ -50,7 +50,7 @@ HTMLAttributes.accessKey
 optional actionDescriptionMap: ActionDescriptionMap;
 ```
 
-Defined in: [src/components/FooterLegend.ts:53](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L53)
+Defined in: [src/components/FooterLegend.ts:53](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L53)
 
 #### Inherited from
 
@@ -1111,7 +1111,7 @@ HTMLAttributes.autoSave
 children: ReactNode;
 ```
 
-Defined in: [src/components/Focusable.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Focusable.ts#L8)
+Defined in: [src/components/Focusable.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Focusable.ts#L8)
 
 #### Overrides
 
@@ -1295,7 +1295,7 @@ HTMLAttributes.draggable
 optional flow-children: string;
 ```
 
-Defined in: [src/components/Focusable.ts:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Focusable.ts#L9)
+Defined in: [src/components/Focusable.ts:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Focusable.ts#L9)
 
 ***
 
@@ -1305,7 +1305,7 @@ Defined in: [src/components/Focusable.ts:9](https://github.com/shdwmtr/plugutil/
 optional focusClassName: string;
 ```
 
-Defined in: [src/components/Focusable.ts:10](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Focusable.ts#L10)
+Defined in: [src/components/Focusable.ts:10](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Focusable.ts#L10)
 
 ***
 
@@ -1315,7 +1315,7 @@ Defined in: [src/components/Focusable.ts:10](https://github.com/shdwmtr/plugutil
 optional focusWithinClassName: string;
 ```
 
-Defined in: [src/components/Focusable.ts:11](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Focusable.ts#L11)
+Defined in: [src/components/Focusable.ts:11](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Focusable.ts#L11)
 
 ***
 
@@ -1521,7 +1521,7 @@ HTMLAttributes.lang
 optional noFocusRing: boolean;
 ```
 
-Defined in: [src/components/Focusable.ts:12](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Focusable.ts#L12)
+Defined in: [src/components/Focusable.ts:12](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Focusable.ts#L12)
 
 ***
 
@@ -1563,7 +1563,7 @@ HTMLAttributes.onAbortCapture
 optional onActivate: (e: CustomEvent) => void;
 ```
 
-Defined in: [src/components/Focusable.ts:13](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Focusable.ts#L13)
+Defined in: [src/components/Focusable.ts:13](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Focusable.ts#L13)
 
 #### Parameters
 
@@ -1775,7 +1775,7 @@ HTMLAttributes.onBlurCapture
 optional onButtonDown: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:59](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L59)
+Defined in: [src/components/FooterLegend.ts:59](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L59)
 
 #### Parameters
 
@@ -1799,7 +1799,7 @@ Defined in: [src/components/FooterLegend.ts:59](https://github.com/shdwmtr/plugu
 optional onButtonUp: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:60](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L60)
+Defined in: [src/components/FooterLegend.ts:60](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L60)
 
 #### Parameters
 
@@ -1823,7 +1823,7 @@ Defined in: [src/components/FooterLegend.ts:60](https://github.com/shdwmtr/plugu
 optional onCancel: (e: CustomEvent) => void;
 ```
 
-Defined in: [src/components/Focusable.ts:14](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Focusable.ts#L14)
+Defined in: [src/components/Focusable.ts:14](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Focusable.ts#L14)
 
 #### Parameters
 
@@ -1843,7 +1843,7 @@ Defined in: [src/components/Focusable.ts:14](https://github.com/shdwmtr/plugutil
 optional onCancelActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:55](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L55)
+Defined in: [src/components/FooterLegend.ts:55](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L55)
 
 #### Inherited from
 
@@ -1857,7 +1857,7 @@ Defined in: [src/components/FooterLegend.ts:55](https://github.com/shdwmtr/plugu
 optional onCancelButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:62](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L62)
+Defined in: [src/components/FooterLegend.ts:62](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L62)
 
 #### Parameters
 
@@ -2681,7 +2681,7 @@ HTMLAttributes.onFocusCapture
 optional onGamepadBlur: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:67](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L67)
+Defined in: [src/components/FooterLegend.ts:67](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L67)
 
 #### Parameters
 
@@ -2705,7 +2705,7 @@ Defined in: [src/components/FooterLegend.ts:67](https://github.com/shdwmtr/plugu
 optional onGamepadDirection: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:65](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L65)
+Defined in: [src/components/FooterLegend.ts:65](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L65)
 
 #### Parameters
 
@@ -2729,7 +2729,7 @@ Defined in: [src/components/FooterLegend.ts:65](https://github.com/shdwmtr/plugu
 optional onGamepadFocus: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:66](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L66)
+Defined in: [src/components/FooterLegend.ts:66](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L66)
 
 #### Parameters
 
@@ -3105,7 +3105,7 @@ HTMLAttributes.onLostPointerCaptureCapture
 optional onMenuActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:58](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L58)
+Defined in: [src/components/FooterLegend.ts:58](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L58)
 
 #### Inherited from
 
@@ -3119,7 +3119,7 @@ Defined in: [src/components/FooterLegend.ts:58](https://github.com/shdwmtr/plugu
 optional onMenuButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:68](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L68)
+Defined in: [src/components/FooterLegend.ts:68](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L68)
 
 #### Parameters
 
@@ -3335,7 +3335,7 @@ HTMLAttributes.onMouseUpCapture
 optional onOKActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:54](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L54)
+Defined in: [src/components/FooterLegend.ts:54](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L54)
 
 #### Inherited from
 
@@ -3349,7 +3349,7 @@ Defined in: [src/components/FooterLegend.ts:54](https://github.com/shdwmtr/plugu
 optional onOKButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:61](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L61)
+Defined in: [src/components/FooterLegend.ts:61](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L61)
 
 #### Parameters
 
@@ -3373,7 +3373,7 @@ Defined in: [src/components/FooterLegend.ts:61](https://github.com/shdwmtr/plugu
 optional onOptionsActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:57](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L57)
+Defined in: [src/components/FooterLegend.ts:57](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L57)
 
 #### Inherited from
 
@@ -3387,7 +3387,7 @@ Defined in: [src/components/FooterLegend.ts:57](https://github.com/shdwmtr/plugu
 optional onOptionsButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:64](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L64)
+Defined in: [src/components/FooterLegend.ts:64](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L64)
 
 #### Parameters
 
@@ -3923,7 +3923,7 @@ HTMLAttributes.onScrollCapture
 optional onSecondaryActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:56](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L56)
+Defined in: [src/components/FooterLegend.ts:56](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L56)
 
 #### Inherited from
 
@@ -3937,7 +3937,7 @@ Defined in: [src/components/FooterLegend.ts:56](https://github.com/shdwmtr/plugu
 optional onSecondaryButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:63](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L63)
+Defined in: [src/components/FooterLegend.ts:63](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L63)
 
 #### Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/FooterLegendProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/FooterLegendProps.md
@@ -4,7 +4,7 @@
 
 # Interface: FooterLegendProps
 
-Defined in: [src/components/FooterLegend.ts:52](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L52)
+Defined in: [src/components/FooterLegend.ts:52](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L52)
 
 ## Extended by
 
@@ -23,7 +23,7 @@ Defined in: [src/components/FooterLegend.ts:52](https://github.com/shdwmtr/plugu
 optional actionDescriptionMap: ActionDescriptionMap;
 ```
 
-Defined in: [src/components/FooterLegend.ts:53](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L53)
+Defined in: [src/components/FooterLegend.ts:53](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L53)
 
 ***
 
@@ -33,7 +33,7 @@ Defined in: [src/components/FooterLegend.ts:53](https://github.com/shdwmtr/plugu
 optional onButtonDown: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:59](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L59)
+Defined in: [src/components/FooterLegend.ts:59](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L59)
 
 #### Parameters
 
@@ -53,7 +53,7 @@ Defined in: [src/components/FooterLegend.ts:59](https://github.com/shdwmtr/plugu
 optional onButtonUp: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:60](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L60)
+Defined in: [src/components/FooterLegend.ts:60](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L60)
 
 #### Parameters
 
@@ -73,7 +73,7 @@ Defined in: [src/components/FooterLegend.ts:60](https://github.com/shdwmtr/plugu
 optional onCancelActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:55](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L55)
+Defined in: [src/components/FooterLegend.ts:55](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L55)
 
 ***
 
@@ -83,7 +83,7 @@ Defined in: [src/components/FooterLegend.ts:55](https://github.com/shdwmtr/plugu
 optional onCancelButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:62](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L62)
+Defined in: [src/components/FooterLegend.ts:62](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L62)
 
 #### Parameters
 
@@ -103,7 +103,7 @@ Defined in: [src/components/FooterLegend.ts:62](https://github.com/shdwmtr/plugu
 optional onGamepadBlur: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:67](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L67)
+Defined in: [src/components/FooterLegend.ts:67](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L67)
 
 #### Parameters
 
@@ -123,7 +123,7 @@ Defined in: [src/components/FooterLegend.ts:67](https://github.com/shdwmtr/plugu
 optional onGamepadDirection: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:65](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L65)
+Defined in: [src/components/FooterLegend.ts:65](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L65)
 
 #### Parameters
 
@@ -143,7 +143,7 @@ Defined in: [src/components/FooterLegend.ts:65](https://github.com/shdwmtr/plugu
 optional onGamepadFocus: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:66](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L66)
+Defined in: [src/components/FooterLegend.ts:66](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L66)
 
 #### Parameters
 
@@ -163,7 +163,7 @@ Defined in: [src/components/FooterLegend.ts:66](https://github.com/shdwmtr/plugu
 optional onMenuActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:58](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L58)
+Defined in: [src/components/FooterLegend.ts:58](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L58)
 
 ***
 
@@ -173,7 +173,7 @@ Defined in: [src/components/FooterLegend.ts:58](https://github.com/shdwmtr/plugu
 optional onMenuButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:68](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L68)
+Defined in: [src/components/FooterLegend.ts:68](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L68)
 
 #### Parameters
 
@@ -193,7 +193,7 @@ Defined in: [src/components/FooterLegend.ts:68](https://github.com/shdwmtr/plugu
 optional onOKActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:54](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L54)
+Defined in: [src/components/FooterLegend.ts:54](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L54)
 
 ***
 
@@ -203,7 +203,7 @@ Defined in: [src/components/FooterLegend.ts:54](https://github.com/shdwmtr/plugu
 optional onOKButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:61](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L61)
+Defined in: [src/components/FooterLegend.ts:61](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L61)
 
 #### Parameters
 
@@ -223,7 +223,7 @@ Defined in: [src/components/FooterLegend.ts:61](https://github.com/shdwmtr/plugu
 optional onOptionsActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:57](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L57)
+Defined in: [src/components/FooterLegend.ts:57](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L57)
 
 ***
 
@@ -233,7 +233,7 @@ Defined in: [src/components/FooterLegend.ts:57](https://github.com/shdwmtr/plugu
 optional onOptionsButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:64](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L64)
+Defined in: [src/components/FooterLegend.ts:64](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L64)
 
 #### Parameters
 
@@ -253,7 +253,7 @@ Defined in: [src/components/FooterLegend.ts:64](https://github.com/shdwmtr/plugu
 optional onSecondaryActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:56](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L56)
+Defined in: [src/components/FooterLegend.ts:56](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L56)
 
 ***
 
@@ -263,7 +263,7 @@ Defined in: [src/components/FooterLegend.ts:56](https://github.com/shdwmtr/plugu
 optional onSecondaryButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:63](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L63)
+Defined in: [src/components/FooterLegend.ts:63](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L63)
 
 #### Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/GamepadEventDetail.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/GamepadEventDetail.md
@@ -4,7 +4,7 @@
 
 # Interface: GamepadEventDetail
 
-Defined in: [src/components/FooterLegend.ts:41](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L41)
+Defined in: [src/components/FooterLegend.ts:41](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L41)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/components/FooterLegend.ts:41](https://github.com/shdwmtr/plugu
 button: number;
 ```
 
-Defined in: [src/components/FooterLegend.ts:42](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L42)
+Defined in: [src/components/FooterLegend.ts:42](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L42)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/components/FooterLegend.ts:42](https://github.com/shdwmtr/plugu
 optional is_repeat: boolean;
 ```
 
-Defined in: [src/components/FooterLegend.ts:43](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L43)
+Defined in: [src/components/FooterLegend.ts:43](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L43)
 
 ***
 
@@ -34,4 +34,4 @@ Defined in: [src/components/FooterLegend.ts:43](https://github.com/shdwmtr/plugu
 source: number;
 ```
 
-Defined in: [src/components/FooterLegend.ts:44](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L44)
+Defined in: [src/components/FooterLegend.ts:44](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L44)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/LifetimeNotification.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/LifetimeNotification.md
@@ -4,7 +4,7 @@
 
 # Interface: LifetimeNotification
 
-Defined in: [src/globals/SteamClient.ts:205](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L205)
+Defined in: [src/globals/SteamClient.ts:205](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L205)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/globals/SteamClient.ts:205](https://github.com/shdwmtr/plugutil
 bRunning: boolean;
 ```
 
-Defined in: [src/globals/SteamClient.ts:208](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L208)
+Defined in: [src/globals/SteamClient.ts:208](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L208)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/globals/SteamClient.ts:208](https://github.com/shdwmtr/plugutil
 nInstanceID: number;
 ```
 
-Defined in: [src/globals/SteamClient.ts:207](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L207)
+Defined in: [src/globals/SteamClient.ts:207](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L207)
 
 ***
 
@@ -34,6 +34,6 @@ Defined in: [src/globals/SteamClient.ts:207](https://github.com/shdwmtr/plugutil
 unAppID: number;
 ```
 
-Defined in: [src/globals/SteamClient.ts:206](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L206)
+Defined in: [src/globals/SteamClient.ts:206](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L206)
 
 is not properly set by Steam for non-steam game shortcuts, so it defaults to 0 for them

--- a/docs/ui/developers/plugins/typescript/client/interfaces/LogoPosition.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/LogoPosition.md
@@ -4,7 +4,7 @@
 
 # Interface: LogoPosition
 
-Defined in: [src/globals/SteamClient.ts:226](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L226)
+Defined in: [src/globals/SteamClient.ts:226](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L226)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/globals/SteamClient.ts:226](https://github.com/shdwmtr/plugutil
 nHeightPct: number;
 ```
 
-Defined in: [src/globals/SteamClient.ts:229](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L229)
+Defined in: [src/globals/SteamClient.ts:229](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L229)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/globals/SteamClient.ts:229](https://github.com/shdwmtr/plugutil
 nWidthPct: number;
 ```
 
-Defined in: [src/globals/SteamClient.ts:228](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L228)
+Defined in: [src/globals/SteamClient.ts:228](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L228)
 
 ***
 
@@ -34,4 +34,4 @@ Defined in: [src/globals/SteamClient.ts:228](https://github.com/shdwmtr/plugutil
 pinnedPosition: LogoPinPositions;
 ```
 
-Defined in: [src/globals/SteamClient.ts:227](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L227)
+Defined in: [src/globals/SteamClient.ts:227](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L227)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/MarqueeProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/MarqueeProps.md
@@ -4,7 +4,7 @@
 
 # Interface: MarqueeProps
 
-Defined in: [src/components/Marquee.ts:5](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Marquee.ts#L5)
+Defined in: [src/components/Marquee.ts:5](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Marquee.ts#L5)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/components/Marquee.ts:5](https://github.com/shdwmtr/plugutil/bl
 optional center: boolean;
 ```
 
-Defined in: [src/components/Marquee.ts:11](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Marquee.ts#L11)
+Defined in: [src/components/Marquee.ts:11](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Marquee.ts#L11)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/components/Marquee.ts:11](https://github.com/shdwmtr/plugutil/b
 children: ReactNode;
 ```
 
-Defined in: [src/components/Marquee.ts:15](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Marquee.ts#L15)
+Defined in: [src/components/Marquee.ts:15](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Marquee.ts#L15)
 
 ***
 
@@ -34,7 +34,7 @@ Defined in: [src/components/Marquee.ts:15](https://github.com/shdwmtr/plugutil/b
 optional className: string;
 ```
 
-Defined in: [src/components/Marquee.ts:14](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Marquee.ts#L14)
+Defined in: [src/components/Marquee.ts:14](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Marquee.ts#L14)
 
 ***
 
@@ -44,7 +44,7 @@ Defined in: [src/components/Marquee.ts:14](https://github.com/shdwmtr/plugutil/b
 optional delay: number;
 ```
 
-Defined in: [src/components/Marquee.ts:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Marquee.ts#L9)
+Defined in: [src/components/Marquee.ts:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Marquee.ts#L9)
 
 ***
 
@@ -54,7 +54,7 @@ Defined in: [src/components/Marquee.ts:9](https://github.com/shdwmtr/plugutil/bl
 optional direction: "left" | "right";
 ```
 
-Defined in: [src/components/Marquee.ts:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Marquee.ts#L7)
+Defined in: [src/components/Marquee.ts:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Marquee.ts#L7)
 
 ***
 
@@ -64,7 +64,7 @@ Defined in: [src/components/Marquee.ts:7](https://github.com/shdwmtr/plugutil/bl
 optional fadeLength: number;
 ```
 
-Defined in: [src/components/Marquee.ts:10](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Marquee.ts#L10)
+Defined in: [src/components/Marquee.ts:10](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Marquee.ts#L10)
 
 ***
 
@@ -74,7 +74,7 @@ Defined in: [src/components/Marquee.ts:10](https://github.com/shdwmtr/plugutil/b
 optional play: boolean;
 ```
 
-Defined in: [src/components/Marquee.ts:6](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Marquee.ts#L6)
+Defined in: [src/components/Marquee.ts:6](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Marquee.ts#L6)
 
 ***
 
@@ -84,7 +84,7 @@ Defined in: [src/components/Marquee.ts:6](https://github.com/shdwmtr/plugutil/bl
 optional resetOnPause: boolean;
 ```
 
-Defined in: [src/components/Marquee.ts:12](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Marquee.ts#L12)
+Defined in: [src/components/Marquee.ts:12](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Marquee.ts#L12)
 
 ***
 
@@ -94,7 +94,7 @@ Defined in: [src/components/Marquee.ts:12](https://github.com/shdwmtr/plugutil/b
 optional speed: number;
 ```
 
-Defined in: [src/components/Marquee.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Marquee.ts#L8)
+Defined in: [src/components/Marquee.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Marquee.ts#L8)
 
 ***
 
@@ -104,4 +104,4 @@ Defined in: [src/components/Marquee.ts:8](https://github.com/shdwmtr/plugutil/bl
 optional style: CSSProperties;
 ```
 
-Defined in: [src/components/Marquee.ts:13](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Marquee.ts#L13)
+Defined in: [src/components/Marquee.ts:13](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Marquee.ts#L13)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/MenuGroupProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/MenuGroupProps.md
@@ -4,7 +4,7 @@
 
 # Interface: MenuGroupProps
 
-Defined in: [src/components/Menu.ts:25](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Menu.ts#L25)
+Defined in: [src/components/Menu.ts:25](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Menu.ts#L25)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/components/Menu.ts:25](https://github.com/shdwmtr/plugutil/blob
 optional children: ReactNode;
 ```
 
-Defined in: [src/components/Menu.ts:28](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Menu.ts#L28)
+Defined in: [src/components/Menu.ts:28](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Menu.ts#L28)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/components/Menu.ts:28](https://github.com/shdwmtr/plugutil/blob
 optional disabled: boolean;
 ```
 
-Defined in: [src/components/Menu.ts:27](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Menu.ts#L27)
+Defined in: [src/components/Menu.ts:27](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Menu.ts#L27)
 
 ***
 
@@ -34,4 +34,4 @@ Defined in: [src/components/Menu.ts:27](https://github.com/shdwmtr/plugutil/blob
 label: string;
 ```
 
-Defined in: [src/components/Menu.ts:26](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Menu.ts#L26)
+Defined in: [src/components/Menu.ts:26](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Menu.ts#L26)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/MenuItemProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/MenuItemProps.md
@@ -4,7 +4,7 @@
 
 # Interface: MenuItemProps
 
-Defined in: [src/components/Menu.ts:37](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Menu.ts#L37)
+Defined in: [src/components/Menu.ts:37](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Menu.ts#L37)
 
 ## Extends
 
@@ -18,7 +18,7 @@ Defined in: [src/components/Menu.ts:37](https://github.com/shdwmtr/plugutil/blob
 optional actionDescriptionMap: ActionDescriptionMap;
 ```
 
-Defined in: [src/components/FooterLegend.ts:53](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L53)
+Defined in: [src/components/FooterLegend.ts:53](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L53)
 
 #### Inherited from
 
@@ -32,7 +32,7 @@ Defined in: [src/components/FooterLegend.ts:53](https://github.com/shdwmtr/plugu
 optional bInteractableItem: boolean;
 ```
 
-Defined in: [src/components/Menu.ts:38](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Menu.ts#L38)
+Defined in: [src/components/Menu.ts:38](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Menu.ts#L38)
 
 ***
 
@@ -42,7 +42,7 @@ Defined in: [src/components/Menu.ts:38](https://github.com/shdwmtr/plugutil/blob
 optional bPlayAudio: boolean;
 ```
 
-Defined in: [src/components/Menu.ts:45](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Menu.ts#L45)
+Defined in: [src/components/Menu.ts:45](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Menu.ts#L45)
 
 ***
 
@@ -52,7 +52,7 @@ Defined in: [src/components/Menu.ts:45](https://github.com/shdwmtr/plugutil/blob
 optional children: ReactNode;
 ```
 
-Defined in: [src/components/Menu.ts:47](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Menu.ts#L47)
+Defined in: [src/components/Menu.ts:47](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Menu.ts#L47)
 
 ***
 
@@ -62,7 +62,7 @@ Defined in: [src/components/Menu.ts:47](https://github.com/shdwmtr/plugutil/blob
 optional disabled: boolean;
 ```
 
-Defined in: [src/components/Menu.ts:44](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Menu.ts#L44)
+Defined in: [src/components/Menu.ts:44](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Menu.ts#L44)
 
 ***
 
@@ -72,7 +72,7 @@ Defined in: [src/components/Menu.ts:44](https://github.com/shdwmtr/plugutil/blob
 optional onButtonDown: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:59](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L59)
+Defined in: [src/components/FooterLegend.ts:59](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L59)
 
 #### Parameters
 
@@ -96,7 +96,7 @@ Defined in: [src/components/FooterLegend.ts:59](https://github.com/shdwmtr/plugu
 optional onButtonUp: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:60](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L60)
+Defined in: [src/components/FooterLegend.ts:60](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L60)
 
 #### Parameters
 
@@ -120,7 +120,7 @@ Defined in: [src/components/FooterLegend.ts:60](https://github.com/shdwmtr/plugu
 optional onCancelActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:55](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L55)
+Defined in: [src/components/FooterLegend.ts:55](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L55)
 
 #### Inherited from
 
@@ -134,7 +134,7 @@ Defined in: [src/components/FooterLegend.ts:55](https://github.com/shdwmtr/plugu
 optional onCancelButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:62](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L62)
+Defined in: [src/components/FooterLegend.ts:62](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L62)
 
 #### Parameters
 
@@ -158,7 +158,7 @@ Defined in: [src/components/FooterLegend.ts:62](https://github.com/shdwmtr/plugu
 optional onGamepadBlur: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:67](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L67)
+Defined in: [src/components/FooterLegend.ts:67](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L67)
 
 #### Parameters
 
@@ -182,7 +182,7 @@ Defined in: [src/components/FooterLegend.ts:67](https://github.com/shdwmtr/plugu
 optional onGamepadDirection: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:65](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L65)
+Defined in: [src/components/FooterLegend.ts:65](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L65)
 
 #### Parameters
 
@@ -206,7 +206,7 @@ Defined in: [src/components/FooterLegend.ts:65](https://github.com/shdwmtr/plugu
 optional onGamepadFocus: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:66](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L66)
+Defined in: [src/components/FooterLegend.ts:66](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L66)
 
 #### Parameters
 
@@ -230,7 +230,7 @@ Defined in: [src/components/FooterLegend.ts:66](https://github.com/shdwmtr/plugu
 optional onMenuActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:58](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L58)
+Defined in: [src/components/FooterLegend.ts:58](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L58)
 
 #### Inherited from
 
@@ -244,7 +244,7 @@ Defined in: [src/components/FooterLegend.ts:58](https://github.com/shdwmtr/plugu
 optional onMenuButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:68](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L68)
+Defined in: [src/components/FooterLegend.ts:68](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L68)
 
 #### Parameters
 
@@ -268,7 +268,7 @@ Defined in: [src/components/FooterLegend.ts:68](https://github.com/shdwmtr/plugu
 optional onOKActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:54](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L54)
+Defined in: [src/components/FooterLegend.ts:54](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L54)
 
 #### Inherited from
 
@@ -282,7 +282,7 @@ Defined in: [src/components/FooterLegend.ts:54](https://github.com/shdwmtr/plugu
 optional onOKButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:61](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L61)
+Defined in: [src/components/FooterLegend.ts:61](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L61)
 
 #### Parameters
 
@@ -306,7 +306,7 @@ Defined in: [src/components/FooterLegend.ts:61](https://github.com/shdwmtr/plugu
 optional onOptionsActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:57](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L57)
+Defined in: [src/components/FooterLegend.ts:57](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L57)
 
 #### Inherited from
 
@@ -320,7 +320,7 @@ Defined in: [src/components/FooterLegend.ts:57](https://github.com/shdwmtr/plugu
 optional onOptionsButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:64](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L64)
+Defined in: [src/components/FooterLegend.ts:64](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L64)
 
 #### Parameters
 
@@ -344,7 +344,7 @@ Defined in: [src/components/FooterLegend.ts:64](https://github.com/shdwmtr/plugu
 optional onSecondaryActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:56](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L56)
+Defined in: [src/components/FooterLegend.ts:56](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L56)
 
 #### Inherited from
 
@@ -358,7 +358,7 @@ Defined in: [src/components/FooterLegend.ts:56](https://github.com/shdwmtr/plugu
 optional onSecondaryButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:63](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L63)
+Defined in: [src/components/FooterLegend.ts:63](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L63)
 
 #### Parameters
 
@@ -382,7 +382,7 @@ Defined in: [src/components/FooterLegend.ts:63](https://github.com/shdwmtr/plugu
 optional selected: boolean;
 ```
 
-Defined in: [src/components/Menu.ts:43](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Menu.ts#L43)
+Defined in: [src/components/Menu.ts:43](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Menu.ts#L43)
 
 ***
 
@@ -392,7 +392,7 @@ Defined in: [src/components/Menu.ts:43](https://github.com/shdwmtr/plugutil/blob
 optional tone: "positive" | "emphasis" | "destructive";
 ```
 
-Defined in: [src/components/Menu.ts:46](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Menu.ts#L46)
+Defined in: [src/components/Menu.ts:46](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Menu.ts#L46)
 
 ## Methods
 
@@ -402,7 +402,7 @@ Defined in: [src/components/Menu.ts:46](https://github.com/shdwmtr/plugutil/blob
 optional onClick(evt: Event): void
 ```
 
-Defined in: [src/components/Menu.ts:39](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Menu.ts#L39)
+Defined in: [src/components/Menu.ts:39](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Menu.ts#L39)
 
 #### Parameters
 
@@ -422,7 +422,7 @@ Defined in: [src/components/Menu.ts:39](https://github.com/shdwmtr/plugutil/blob
 optional onMouseEnter(evt: MouseEvent): void
 ```
 
-Defined in: [src/components/Menu.ts:41](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Menu.ts#L41)
+Defined in: [src/components/Menu.ts:41](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Menu.ts#L41)
 
 #### Parameters
 
@@ -442,7 +442,7 @@ Defined in: [src/components/Menu.ts:41](https://github.com/shdwmtr/plugutil/blob
 optional onMoveRight(): void
 ```
 
-Defined in: [src/components/Menu.ts:42](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Menu.ts#L42)
+Defined in: [src/components/Menu.ts:42](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Menu.ts#L42)
 
 #### Returns
 
@@ -456,7 +456,7 @@ Defined in: [src/components/Menu.ts:42](https://github.com/shdwmtr/plugutil/blob
 optional onSelected(evt: Event): void
 ```
 
-Defined in: [src/components/Menu.ts:40](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Menu.ts#L40)
+Defined in: [src/components/Menu.ts:40](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Menu.ts#L40)
 
 #### Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/MenuProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/MenuProps.md
@@ -4,7 +4,7 @@
 
 # Interface: MenuProps
 
-Defined in: [src/components/Menu.ts:13](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Menu.ts#L13)
+Defined in: [src/components/Menu.ts:13](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Menu.ts#L13)
 
 ## Extends
 
@@ -18,7 +18,7 @@ Defined in: [src/components/Menu.ts:13](https://github.com/shdwmtr/plugutil/blob
 optional actionDescriptionMap: ActionDescriptionMap;
 ```
 
-Defined in: [src/components/FooterLegend.ts:53](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L53)
+Defined in: [src/components/FooterLegend.ts:53](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L53)
 
 #### Inherited from
 
@@ -32,7 +32,7 @@ Defined in: [src/components/FooterLegend.ts:53](https://github.com/shdwmtr/plugu
 optional cancelText: string;
 ```
 
-Defined in: [src/components/Menu.ts:16](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Menu.ts#L16)
+Defined in: [src/components/Menu.ts:16](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Menu.ts#L16)
 
 ***
 
@@ -42,7 +42,7 @@ Defined in: [src/components/Menu.ts:16](https://github.com/shdwmtr/plugutil/blob
 optional children: ReactNode;
 ```
 
-Defined in: [src/components/Menu.ts:17](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Menu.ts#L17)
+Defined in: [src/components/Menu.ts:17](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Menu.ts#L17)
 
 ***
 
@@ -52,7 +52,7 @@ Defined in: [src/components/Menu.ts:17](https://github.com/shdwmtr/plugutil/blob
 label: string;
 ```
 
-Defined in: [src/components/Menu.ts:14](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Menu.ts#L14)
+Defined in: [src/components/Menu.ts:14](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Menu.ts#L14)
 
 ***
 
@@ -62,7 +62,7 @@ Defined in: [src/components/Menu.ts:14](https://github.com/shdwmtr/plugutil/blob
 optional onButtonDown: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:59](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L59)
+Defined in: [src/components/FooterLegend.ts:59](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L59)
 
 #### Parameters
 
@@ -86,7 +86,7 @@ Defined in: [src/components/FooterLegend.ts:59](https://github.com/shdwmtr/plugu
 optional onButtonUp: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:60](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L60)
+Defined in: [src/components/FooterLegend.ts:60](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L60)
 
 #### Parameters
 
@@ -110,7 +110,7 @@ Defined in: [src/components/FooterLegend.ts:60](https://github.com/shdwmtr/plugu
 optional onCancelActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:55](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L55)
+Defined in: [src/components/FooterLegend.ts:55](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L55)
 
 #### Inherited from
 
@@ -124,7 +124,7 @@ Defined in: [src/components/FooterLegend.ts:55](https://github.com/shdwmtr/plugu
 optional onCancelButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:62](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L62)
+Defined in: [src/components/FooterLegend.ts:62](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L62)
 
 #### Parameters
 
@@ -148,7 +148,7 @@ Defined in: [src/components/FooterLegend.ts:62](https://github.com/shdwmtr/plugu
 optional onGamepadBlur: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:67](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L67)
+Defined in: [src/components/FooterLegend.ts:67](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L67)
 
 #### Parameters
 
@@ -172,7 +172,7 @@ Defined in: [src/components/FooterLegend.ts:67](https://github.com/shdwmtr/plugu
 optional onGamepadDirection: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:65](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L65)
+Defined in: [src/components/FooterLegend.ts:65](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L65)
 
 #### Parameters
 
@@ -196,7 +196,7 @@ Defined in: [src/components/FooterLegend.ts:65](https://github.com/shdwmtr/plugu
 optional onGamepadFocus: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:66](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L66)
+Defined in: [src/components/FooterLegend.ts:66](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L66)
 
 #### Parameters
 
@@ -220,7 +220,7 @@ Defined in: [src/components/FooterLegend.ts:66](https://github.com/shdwmtr/plugu
 optional onMenuActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:58](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L58)
+Defined in: [src/components/FooterLegend.ts:58](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L58)
 
 #### Inherited from
 
@@ -234,7 +234,7 @@ Defined in: [src/components/FooterLegend.ts:58](https://github.com/shdwmtr/plugu
 optional onMenuButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:68](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L68)
+Defined in: [src/components/FooterLegend.ts:68](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L68)
 
 #### Parameters
 
@@ -258,7 +258,7 @@ Defined in: [src/components/FooterLegend.ts:68](https://github.com/shdwmtr/plugu
 optional onOKActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:54](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L54)
+Defined in: [src/components/FooterLegend.ts:54](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L54)
 
 #### Inherited from
 
@@ -272,7 +272,7 @@ Defined in: [src/components/FooterLegend.ts:54](https://github.com/shdwmtr/plugu
 optional onOKButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:61](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L61)
+Defined in: [src/components/FooterLegend.ts:61](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L61)
 
 #### Parameters
 
@@ -296,7 +296,7 @@ Defined in: [src/components/FooterLegend.ts:61](https://github.com/shdwmtr/plugu
 optional onOptionsActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:57](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L57)
+Defined in: [src/components/FooterLegend.ts:57](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L57)
 
 #### Inherited from
 
@@ -310,7 +310,7 @@ Defined in: [src/components/FooterLegend.ts:57](https://github.com/shdwmtr/plugu
 optional onOptionsButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:64](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L64)
+Defined in: [src/components/FooterLegend.ts:64](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L64)
 
 #### Parameters
 
@@ -334,7 +334,7 @@ Defined in: [src/components/FooterLegend.ts:64](https://github.com/shdwmtr/plugu
 optional onSecondaryActionDescription: ReactNode;
 ```
 
-Defined in: [src/components/FooterLegend.ts:56](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L56)
+Defined in: [src/components/FooterLegend.ts:56](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L56)
 
 #### Inherited from
 
@@ -348,7 +348,7 @@ Defined in: [src/components/FooterLegend.ts:56](https://github.com/shdwmtr/plugu
 optional onSecondaryButton: (evt: GamepadEvent) => void;
 ```
 
-Defined in: [src/components/FooterLegend.ts:63](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L63)
+Defined in: [src/components/FooterLegend.ts:63](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L63)
 
 #### Parameters
 
@@ -372,7 +372,7 @@ Defined in: [src/components/FooterLegend.ts:63](https://github.com/shdwmtr/plugu
 optional onCancel(): void
 ```
 
-Defined in: [src/components/Menu.ts:15](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Menu.ts#L15)
+Defined in: [src/components/Menu.ts:15](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Menu.ts#L15)
 
 #### Returns
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/MenuStore.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/MenuStore.md
@@ -4,7 +4,7 @@
 
 # Interface: MenuStore
 
-Defined in: [src/modules/Router.ts:68](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L68)
+Defined in: [src/modules/Router.ts:68](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L68)
 
 ## Methods
 
@@ -14,7 +14,7 @@ Defined in: [src/modules/Router.ts:68](https://github.com/shdwmtr/plugutil/blob/
 OpenMainMenu(): void
 ```
 
-Defined in: [src/modules/Router.ts:71](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L71)
+Defined in: [src/modules/Router.ts:71](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L71)
 
 #### Returns
 
@@ -28,7 +28,7 @@ Defined in: [src/modules/Router.ts:71](https://github.com/shdwmtr/plugutil/blob/
 OpenQuickAccessMenu(quickAccessTab?: QuickAccessTab): void
 ```
 
-Defined in: [src/modules/Router.ts:70](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L70)
+Defined in: [src/modules/Router.ts:70](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L70)
 
 #### Parameters
 
@@ -48,7 +48,7 @@ Defined in: [src/modules/Router.ts:70](https://github.com/shdwmtr/plugutil/blob/
 OpenSideMenu(sideMenu: SideMenu): void
 ```
 
-Defined in: [src/modules/Router.ts:69](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L69)
+Defined in: [src/modules/Router.ts:69](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L69)
 
 #### Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/ModalRootProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/ModalRootProps.md
@@ -4,7 +4,7 @@
 
 # Interface: ModalRootProps
 
-Defined in: [src/components/Modal.tsx:60](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L60)
+Defined in: [src/components/Modal.tsx:60](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L60)
 
 ## Extended by
 
@@ -18,7 +18,7 @@ Defined in: [src/components/Modal.tsx:60](https://github.com/shdwmtr/plugutil/bl
 optional bAllowFullSize: boolean;
 ```
 
-Defined in: [src/components/Modal.tsx:68](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L68)
+Defined in: [src/components/Modal.tsx:68](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L68)
 
 ***
 
@@ -28,7 +28,7 @@ Defined in: [src/components/Modal.tsx:68](https://github.com/shdwmtr/plugutil/bl
 optional bCancelDisabled: boolean;
 ```
 
-Defined in: [src/components/Modal.tsx:73](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L73)
+Defined in: [src/components/Modal.tsx:73](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L73)
 
 ***
 
@@ -38,7 +38,7 @@ Defined in: [src/components/Modal.tsx:73](https://github.com/shdwmtr/plugutil/bl
 optional bDestructiveWarning: boolean;
 ```
 
-Defined in: [src/components/Modal.tsx:69](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L69)
+Defined in: [src/components/Modal.tsx:69](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L69)
 
 ***
 
@@ -48,7 +48,7 @@ Defined in: [src/components/Modal.tsx:69](https://github.com/shdwmtr/plugutil/bl
 optional bDisableBackgroundDismiss: boolean;
 ```
 
-Defined in: [src/components/Modal.tsx:70](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L70)
+Defined in: [src/components/Modal.tsx:70](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L70)
 
 ***
 
@@ -58,7 +58,7 @@ Defined in: [src/components/Modal.tsx:70](https://github.com/shdwmtr/plugutil/bl
 optional bHideCloseIcon: boolean;
 ```
 
-Defined in: [src/components/Modal.tsx:71](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L71)
+Defined in: [src/components/Modal.tsx:71](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L71)
 
 ***
 
@@ -68,7 +68,7 @@ Defined in: [src/components/Modal.tsx:71](https://github.com/shdwmtr/plugutil/bl
 optional bOKDisabled: boolean;
 ```
 
-Defined in: [src/components/Modal.tsx:72](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L72)
+Defined in: [src/components/Modal.tsx:72](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L72)
 
 ***
 
@@ -78,7 +78,7 @@ Defined in: [src/components/Modal.tsx:72](https://github.com/shdwmtr/plugutil/bl
 optional children: ReactNode;
 ```
 
-Defined in: [src/components/Modal.tsx:61](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L61)
+Defined in: [src/components/Modal.tsx:61](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L61)
 
 ***
 
@@ -88,7 +88,7 @@ Defined in: [src/components/Modal.tsx:61](https://github.com/shdwmtr/plugutil/bl
 optional className: string;
 ```
 
-Defined in: [src/components/Modal.tsx:66](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L66)
+Defined in: [src/components/Modal.tsx:66](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L66)
 
 ***
 
@@ -98,7 +98,7 @@ Defined in: [src/components/Modal.tsx:66](https://github.com/shdwmtr/plugutil/bl
 optional modalClassName: string;
 ```
 
-Defined in: [src/components/Modal.tsx:67](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L67)
+Defined in: [src/components/Modal.tsx:67](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L67)
 
 ## Methods
 
@@ -108,7 +108,7 @@ Defined in: [src/components/Modal.tsx:67](https://github.com/shdwmtr/plugutil/bl
 optional closeModal(): void
 ```
 
-Defined in: [src/components/Modal.tsx:63](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L63)
+Defined in: [src/components/Modal.tsx:63](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L63)
 
 #### Returns
 
@@ -122,7 +122,7 @@ Defined in: [src/components/Modal.tsx:63](https://github.com/shdwmtr/plugutil/bl
 optional onCancel(): void
 ```
 
-Defined in: [src/components/Modal.tsx:62](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L62)
+Defined in: [src/components/Modal.tsx:62](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L62)
 
 #### Returns
 
@@ -136,7 +136,7 @@ Defined in: [src/components/Modal.tsx:62](https://github.com/shdwmtr/plugutil/bl
 optional onEscKeypress(): void
 ```
 
-Defined in: [src/components/Modal.tsx:65](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L65)
+Defined in: [src/components/Modal.tsx:65](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L65)
 
 #### Returns
 
@@ -150,7 +150,7 @@ Defined in: [src/components/Modal.tsx:65](https://github.com/shdwmtr/plugutil/bl
 optional onOK(): void
 ```
 
-Defined in: [src/components/Modal.tsx:64](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L64)
+Defined in: [src/components/Modal.tsx:64](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L64)
 
 #### Returns
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/MultiDropdownOption.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/MultiDropdownOption.md
@@ -4,7 +4,7 @@
 
 # Interface: MultiDropdownOption
 
-Defined in: [src/components/Dropdown.ts:14](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L14)
+Defined in: [src/components/Dropdown.ts:14](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L14)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/components/Dropdown.ts:14](https://github.com/shdwmtr/plugutil/
 optional data: undefined;
 ```
 
-Defined in: [src/components/Dropdown.ts:18](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L18)
+Defined in: [src/components/Dropdown.ts:18](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L18)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/components/Dropdown.ts:18](https://github.com/shdwmtr/plugutil/
 label: ReactNode;
 ```
 
-Defined in: [src/components/Dropdown.ts:15](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L15)
+Defined in: [src/components/Dropdown.ts:15](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L15)
 
 ***
 
@@ -34,4 +34,4 @@ Defined in: [src/components/Dropdown.ts:15](https://github.com/shdwmtr/plugutil/
 options: DropdownOption[];
 ```
 
-Defined in: [src/components/Dropdown.ts:16](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L16)
+Defined in: [src/components/Dropdown.ts:16](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L16)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/Navigation.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/Navigation.md
@@ -4,7 +4,7 @@
 
 # Interface: Navigation
 
-Defined in: [src/modules/Router.ts:106](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L106)
+Defined in: [src/modules/Router.ts:106](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L106)
 
 ## Methods
 
@@ -14,7 +14,7 @@ Defined in: [src/modules/Router.ts:106](https://github.com/shdwmtr/plugutil/blob
 CloseSideMenus(): void
 ```
 
-Defined in: [src/modules/Router.ts:120](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L120)
+Defined in: [src/modules/Router.ts:120](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L120)
 
 #### Returns
 
@@ -28,7 +28,7 @@ Defined in: [src/modules/Router.ts:120](https://github.com/shdwmtr/plugutil/blob
 Navigate(path: string): void
 ```
 
-Defined in: [src/modules/Router.ts:107](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L107)
+Defined in: [src/modules/Router.ts:107](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L107)
 
 #### Parameters
 
@@ -48,7 +48,7 @@ Defined in: [src/modules/Router.ts:107](https://github.com/shdwmtr/plugutil/blob
 NavigateBack(): void
 ```
 
-Defined in: [src/modules/Router.ts:108](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L108)
+Defined in: [src/modules/Router.ts:108](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L108)
 
 #### Returns
 
@@ -62,7 +62,7 @@ Defined in: [src/modules/Router.ts:108](https://github.com/shdwmtr/plugutil/blob
 NavigateToAppProperties(): void
 ```
 
-Defined in: [src/modules/Router.ts:109](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L109)
+Defined in: [src/modules/Router.ts:109](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L109)
 
 #### Returns
 
@@ -76,7 +76,7 @@ Defined in: [src/modules/Router.ts:109](https://github.com/shdwmtr/plugutil/blob
 NavigateToChat(): void
 ```
 
-Defined in: [src/modules/Router.ts:112](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L112)
+Defined in: [src/modules/Router.ts:112](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L112)
 
 #### Returns
 
@@ -90,7 +90,7 @@ Defined in: [src/modules/Router.ts:112](https://github.com/shdwmtr/plugutil/blob
 NavigateToExternalWeb(url: string): void
 ```
 
-Defined in: [src/modules/Router.ts:110](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L110)
+Defined in: [src/modules/Router.ts:110](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L110)
 
 #### Parameters
 
@@ -110,7 +110,7 @@ Defined in: [src/modules/Router.ts:110](https://github.com/shdwmtr/plugutil/blob
 NavigateToInvites(): void
 ```
 
-Defined in: [src/modules/Router.ts:111](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L111)
+Defined in: [src/modules/Router.ts:111](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L111)
 
 #### Returns
 
@@ -124,7 +124,7 @@ Defined in: [src/modules/Router.ts:111](https://github.com/shdwmtr/plugutil/blob
 NavigateToLayoutPreview(e: unknown): void
 ```
 
-Defined in: [src/modules/Router.ts:114](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L114)
+Defined in: [src/modules/Router.ts:114](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L114)
 
 #### Parameters
 
@@ -144,7 +144,7 @@ Defined in: [src/modules/Router.ts:114](https://github.com/shdwmtr/plugutil/blob
 NavigateToLibraryTab(): void
 ```
 
-Defined in: [src/modules/Router.ts:113](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L113)
+Defined in: [src/modules/Router.ts:113](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L113)
 
 #### Returns
 
@@ -158,7 +158,7 @@ Defined in: [src/modules/Router.ts:113](https://github.com/shdwmtr/plugutil/blob
 NavigateToSteamWeb(url: string): void
 ```
 
-Defined in: [src/modules/Router.ts:115](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L115)
+Defined in: [src/modules/Router.ts:115](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L115)
 
 #### Parameters
 
@@ -178,7 +178,7 @@ Defined in: [src/modules/Router.ts:115](https://github.com/shdwmtr/plugutil/blob
 OpenMainMenu(): void
 ```
 
-Defined in: [src/modules/Router.ts:118](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L118)
+Defined in: [src/modules/Router.ts:118](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L118)
 
 #### Returns
 
@@ -192,7 +192,7 @@ Defined in: [src/modules/Router.ts:118](https://github.com/shdwmtr/plugutil/blob
 OpenPowerMenu(unknown?: any): void
 ```
 
-Defined in: [src/modules/Router.ts:119](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L119)
+Defined in: [src/modules/Router.ts:119](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L119)
 
 #### Parameters
 
@@ -212,7 +212,7 @@ Defined in: [src/modules/Router.ts:119](https://github.com/shdwmtr/plugutil/blob
 OpenQuickAccessMenu(quickAccessTab?: QuickAccessTab): void
 ```
 
-Defined in: [src/modules/Router.ts:117](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L117)
+Defined in: [src/modules/Router.ts:117](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L117)
 
 #### Parameters
 
@@ -232,7 +232,7 @@ Defined in: [src/modules/Router.ts:117](https://github.com/shdwmtr/plugutil/blob
 OpenSideMenu(sideMenu: SideMenu): void
 ```
 
-Defined in: [src/modules/Router.ts:116](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L116)
+Defined in: [src/modules/Router.ts:116](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L116)
 
 #### Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/NotchLabel.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/NotchLabel.md
@@ -4,7 +4,7 @@
 
 # Interface: NotchLabel
 
-Defined in: [src/components/SliderField.ts:6](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SliderField.ts#L6)
+Defined in: [src/components/SliderField.ts:6](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SliderField.ts#L6)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/components/SliderField.ts:6](https://github.com/shdwmtr/pluguti
 label: string;
 ```
 
-Defined in: [src/components/SliderField.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SliderField.ts#L8)
+Defined in: [src/components/SliderField.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SliderField.ts#L8)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/components/SliderField.ts:8](https://github.com/shdwmtr/pluguti
 notchIndex: number;
 ```
 
-Defined in: [src/components/SliderField.ts:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SliderField.ts#L7)
+Defined in: [src/components/SliderField.ts:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SliderField.ts#L7)
 
 ***
 
@@ -34,4 +34,4 @@ Defined in: [src/components/SliderField.ts:7](https://github.com/shdwmtr/pluguti
 optional value: number;
 ```
 
-Defined in: [src/components/SliderField.ts:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SliderField.ts#L9)
+Defined in: [src/components/SliderField.ts:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SliderField.ts#L9)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/PanelSectionProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/PanelSectionProps.md
@@ -4,7 +4,7 @@
 
 # Interface: PanelSectionProps
 
-Defined in: [src/components/Panel.ts:11](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Panel.ts#L11)
+Defined in: [src/components/Panel.ts:11](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Panel.ts#L11)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/components/Panel.ts:11](https://github.com/shdwmtr/plugutil/blo
 optional children: ReactNode;
 ```
 
-Defined in: [src/components/Panel.ts:14](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Panel.ts#L14)
+Defined in: [src/components/Panel.ts:14](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Panel.ts#L14)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/components/Panel.ts:14](https://github.com/shdwmtr/plugutil/blo
 optional spinner: boolean;
 ```
 
-Defined in: [src/components/Panel.ts:13](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Panel.ts#L13)
+Defined in: [src/components/Panel.ts:13](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Panel.ts#L13)
 
 ***
 
@@ -34,4 +34,4 @@ Defined in: [src/components/Panel.ts:13](https://github.com/shdwmtr/plugutil/blo
 optional title: string;
 ```
 
-Defined in: [src/components/Panel.ts:12](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Panel.ts#L12)
+Defined in: [src/components/Panel.ts:12](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Panel.ts#L12)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/PanelSectionRowProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/PanelSectionRowProps.md
@@ -4,7 +4,7 @@
 
 # Interface: PanelSectionRowProps
 
-Defined in: [src/components/Panel.ts:22](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Panel.ts#L22)
+Defined in: [src/components/Panel.ts:22](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Panel.ts#L22)
 
 ## Properties
 
@@ -14,4 +14,4 @@ Defined in: [src/components/Panel.ts:22](https://github.com/shdwmtr/plugutil/blo
 optional children: ReactNode;
 ```
 
-Defined in: [src/components/Panel.ts:23](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Panel.ts#L23)
+Defined in: [src/components/Panel.ts:23](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Panel.ts#L23)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/Patch.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/Patch.md
@@ -4,7 +4,7 @@
 
 # Interface: Patch
 
-Defined in: [src/utils/patcher.ts:11](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/patcher.ts#L11)
+Defined in: [src/utils/patcher.ts:11](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/patcher.ts#L11)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/utils/patcher.ts:11](https://github.com/shdwmtr/plugutil/blob/b
 handler: GenericPatchHandler;
 ```
 
-Defined in: [src/utils/patcher.ts:17](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/patcher.ts#L17)
+Defined in: [src/utils/patcher.ts:17](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/patcher.ts#L17)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/utils/patcher.ts:17](https://github.com/shdwmtr/plugutil/blob/b
 hasUnpatched: boolean;
 ```
 
-Defined in: [src/utils/patcher.ts:16](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/patcher.ts#L16)
+Defined in: [src/utils/patcher.ts:16](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/patcher.ts#L16)
 
 ***
 
@@ -34,7 +34,7 @@ Defined in: [src/utils/patcher.ts:16](https://github.com/shdwmtr/plugutil/blob/b
 object: any;
 ```
 
-Defined in: [src/utils/patcher.ts:14](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/patcher.ts#L14)
+Defined in: [src/utils/patcher.ts:14](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/patcher.ts#L14)
 
 ***
 
@@ -44,7 +44,7 @@ Defined in: [src/utils/patcher.ts:14](https://github.com/shdwmtr/plugutil/blob/b
 original: Function;
 ```
 
-Defined in: [src/utils/patcher.ts:12](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/patcher.ts#L12)
+Defined in: [src/utils/patcher.ts:12](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/patcher.ts#L12)
 
 ***
 
@@ -54,7 +54,7 @@ Defined in: [src/utils/patcher.ts:12](https://github.com/shdwmtr/plugutil/blob/b
 patchedFunction: any;
 ```
 
-Defined in: [src/utils/patcher.ts:15](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/patcher.ts#L15)
+Defined in: [src/utils/patcher.ts:15](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/patcher.ts#L15)
 
 ***
 
@@ -64,7 +64,7 @@ Defined in: [src/utils/patcher.ts:15](https://github.com/shdwmtr/plugutil/blob/b
 property: string;
 ```
 
-Defined in: [src/utils/patcher.ts:13](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/patcher.ts#L13)
+Defined in: [src/utils/patcher.ts:13](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/patcher.ts#L13)
 
 ***
 
@@ -74,7 +74,7 @@ Defined in: [src/utils/patcher.ts:13](https://github.com/shdwmtr/plugutil/blob/b
 unpatch: () => void;
 ```
 
-Defined in: [src/utils/patcher.ts:19](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/patcher.ts#L19)
+Defined in: [src/utils/patcher.ts:19](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/patcher.ts#L19)
 
 #### Returns
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/PatchOptions.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/PatchOptions.md
@@ -4,7 +4,7 @@
 
 # Interface: PatchOptions
 
-Defined in: [src/utils/patcher.ts:5](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/patcher.ts#L5)
+Defined in: [src/utils/patcher.ts:5](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/patcher.ts#L5)
 
 ## Properties
 
@@ -14,4 +14,4 @@ Defined in: [src/utils/patcher.ts:5](https://github.com/shdwmtr/plugutil/blob/b5
 optional singleShot: boolean;
 ```
 
-Defined in: [src/utils/patcher.ts:6](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/patcher.ts#L6)
+Defined in: [src/utils/patcher.ts:6](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/patcher.ts#L6)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/ProgressBarItemProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/ProgressBarItemProps.md
@@ -4,7 +4,7 @@
 
 # Interface: ProgressBarItemProps
 
-Defined in: [src/components/ProgressBar.ts:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ProgressBar.ts#L7)
+Defined in: [src/components/ProgressBar.ts:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ProgressBar.ts#L7)
 
 ## Extends
 
@@ -22,7 +22,7 @@ Defined in: [src/components/ProgressBar.ts:7](https://github.com/shdwmtr/pluguti
 optional bottomSeparator: "standard" | "thick" | "none";
 ```
 
-Defined in: [src/components/Item.ts:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L9)
+Defined in: [src/components/Item.ts:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L9)
 
 #### Inherited from
 
@@ -38,7 +38,7 @@ ItemProps.bottomSeparator
 optional children: ReactNode;
 ```
 
-Defined in: [src/components/Item.ts:6](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L6)
+Defined in: [src/components/Item.ts:6](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L6)
 
 #### Inherited from
 
@@ -54,7 +54,7 @@ ItemProps.children
 optional description: ReactNode;
 ```
 
-Defined in: [src/components/Item.ts:5](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L5)
+Defined in: [src/components/Item.ts:5](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L5)
 
 #### Inherited from
 
@@ -70,7 +70,7 @@ ItemProps.description
 optional focusable: boolean;
 ```
 
-Defined in: [src/components/ProgressBar.ts:11](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ProgressBar.ts#L11)
+Defined in: [src/components/ProgressBar.ts:11](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ProgressBar.ts#L11)
 
 ***
 
@@ -80,7 +80,7 @@ Defined in: [src/components/ProgressBar.ts:11](https://github.com/shdwmtr/plugut
 optional highlightOnFocus: boolean;
 ```
 
-Defined in: [src/components/Item.ts:12](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L12)
+Defined in: [src/components/Item.ts:12](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L12)
 
 #### Inherited from
 
@@ -96,7 +96,7 @@ ItemProps.highlightOnFocus
 optional icon: ReactNode;
 ```
 
-Defined in: [src/components/Item.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L8)
+Defined in: [src/components/Item.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L8)
 
 #### Inherited from
 
@@ -112,7 +112,7 @@ ItemProps.icon
 optional indentLevel: number;
 ```
 
-Defined in: [src/components/Item.ts:10](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L10)
+Defined in: [src/components/Item.ts:10](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L10)
 
 #### Inherited from
 
@@ -128,7 +128,7 @@ ItemProps.indentLevel
 optional indeterminate: boolean;
 ```
 
-Defined in: [src/components/ProgressBar.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ProgressBar.ts#L8)
+Defined in: [src/components/ProgressBar.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ProgressBar.ts#L8)
 
 ***
 
@@ -138,7 +138,7 @@ Defined in: [src/components/ProgressBar.ts:8](https://github.com/shdwmtr/pluguti
 optional label: ReactNode;
 ```
 
-Defined in: [src/components/Item.ts:4](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L4)
+Defined in: [src/components/Item.ts:4](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L4)
 
 #### Inherited from
 
@@ -154,7 +154,7 @@ ItemProps.label
 optional layout: "below" | "inline";
 ```
 
-Defined in: [src/components/Item.ts:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L7)
+Defined in: [src/components/Item.ts:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L7)
 
 #### Inherited from
 
@@ -170,7 +170,7 @@ ItemProps.layout
 optional nProgress: number;
 ```
 
-Defined in: [src/components/ProgressBar.ts:10](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ProgressBar.ts#L10)
+Defined in: [src/components/ProgressBar.ts:10](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ProgressBar.ts#L10)
 
 ***
 
@@ -180,7 +180,7 @@ Defined in: [src/components/ProgressBar.ts:10](https://github.com/shdwmtr/plugut
 optional nTransitionSec: number;
 ```
 
-Defined in: [src/components/ProgressBar.ts:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ProgressBar.ts#L9)
+Defined in: [src/components/ProgressBar.ts:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ProgressBar.ts#L9)
 
 ***
 
@@ -190,7 +190,7 @@ Defined in: [src/components/ProgressBar.ts:9](https://github.com/shdwmtr/pluguti
 optional tooltip: string;
 ```
 
-Defined in: [src/components/Item.ts:11](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L11)
+Defined in: [src/components/Item.ts:11](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L11)
 
 #### Inherited from
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/ProgressBarProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/ProgressBarProps.md
@@ -4,7 +4,7 @@
 
 # Interface: ProgressBarProps
 
-Defined in: [src/components/ProgressBar.ts:14](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ProgressBar.ts#L14)
+Defined in: [src/components/ProgressBar.ts:14](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ProgressBar.ts#L14)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/components/ProgressBar.ts:14](https://github.com/shdwmtr/plugut
 optional focusable: boolean;
 ```
 
-Defined in: [src/components/ProgressBar.ts:18](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ProgressBar.ts#L18)
+Defined in: [src/components/ProgressBar.ts:18](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ProgressBar.ts#L18)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/components/ProgressBar.ts:18](https://github.com/shdwmtr/plugut
 optional indeterminate: boolean;
 ```
 
-Defined in: [src/components/ProgressBar.ts:15](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ProgressBar.ts#L15)
+Defined in: [src/components/ProgressBar.ts:15](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ProgressBar.ts#L15)
 
 ***
 
@@ -34,7 +34,7 @@ Defined in: [src/components/ProgressBar.ts:15](https://github.com/shdwmtr/plugut
 optional nProgress: number;
 ```
 
-Defined in: [src/components/ProgressBar.ts:17](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ProgressBar.ts#L17)
+Defined in: [src/components/ProgressBar.ts:17](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ProgressBar.ts#L17)
 
 ***
 
@@ -44,4 +44,4 @@ Defined in: [src/components/ProgressBar.ts:17](https://github.com/shdwmtr/plugut
 optional nTransitionSec: number;
 ```
 
-Defined in: [src/components/ProgressBar.ts:16](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ProgressBar.ts#L16)
+Defined in: [src/components/ProgressBar.ts:16](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ProgressBar.ts#L16)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/ProgressBarWithInfoProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/ProgressBarWithInfoProps.md
@@ -4,7 +4,7 @@
 
 # Interface: ProgressBarWithInfoProps
 
-Defined in: [src/components/ProgressBar.ts:21](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ProgressBar.ts#L21)
+Defined in: [src/components/ProgressBar.ts:21](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ProgressBar.ts#L21)
 
 ## Extends
 
@@ -18,7 +18,7 @@ Defined in: [src/components/ProgressBar.ts:21](https://github.com/shdwmtr/plugut
 optional bottomSeparator: "standard" | "thick" | "none";
 ```
 
-Defined in: [src/components/Item.ts:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L9)
+Defined in: [src/components/Item.ts:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L9)
 
 #### Inherited from
 
@@ -32,7 +32,7 @@ Defined in: [src/components/Item.ts:9](https://github.com/shdwmtr/plugutil/blob/
 optional children: ReactNode;
 ```
 
-Defined in: [src/components/Item.ts:6](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L6)
+Defined in: [src/components/Item.ts:6](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L6)
 
 #### Inherited from
 
@@ -46,7 +46,7 @@ Defined in: [src/components/Item.ts:6](https://github.com/shdwmtr/plugutil/blob/
 optional description: ReactNode;
 ```
 
-Defined in: [src/components/Item.ts:5](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L5)
+Defined in: [src/components/Item.ts:5](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L5)
 
 #### Inherited from
 
@@ -60,7 +60,7 @@ Defined in: [src/components/Item.ts:5](https://github.com/shdwmtr/plugutil/blob/
 optional focusable: boolean;
 ```
 
-Defined in: [src/components/ProgressBar.ts:11](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ProgressBar.ts#L11)
+Defined in: [src/components/ProgressBar.ts:11](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ProgressBar.ts#L11)
 
 #### Inherited from
 
@@ -74,7 +74,7 @@ Defined in: [src/components/ProgressBar.ts:11](https://github.com/shdwmtr/plugut
 optional highlightOnFocus: boolean;
 ```
 
-Defined in: [src/components/Item.ts:12](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L12)
+Defined in: [src/components/Item.ts:12](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L12)
 
 #### Inherited from
 
@@ -88,7 +88,7 @@ Defined in: [src/components/Item.ts:12](https://github.com/shdwmtr/plugutil/blob
 optional icon: ReactNode;
 ```
 
-Defined in: [src/components/Item.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L8)
+Defined in: [src/components/Item.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L8)
 
 #### Inherited from
 
@@ -102,7 +102,7 @@ Defined in: [src/components/Item.ts:8](https://github.com/shdwmtr/plugutil/blob/
 optional indentLevel: number;
 ```
 
-Defined in: [src/components/Item.ts:10](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L10)
+Defined in: [src/components/Item.ts:10](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L10)
 
 #### Inherited from
 
@@ -116,7 +116,7 @@ Defined in: [src/components/Item.ts:10](https://github.com/shdwmtr/plugutil/blob
 optional indeterminate: boolean;
 ```
 
-Defined in: [src/components/ProgressBar.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ProgressBar.ts#L8)
+Defined in: [src/components/ProgressBar.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ProgressBar.ts#L8)
 
 #### Inherited from
 
@@ -130,7 +130,7 @@ Defined in: [src/components/ProgressBar.ts:8](https://github.com/shdwmtr/pluguti
 optional label: ReactNode;
 ```
 
-Defined in: [src/components/Item.ts:4](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L4)
+Defined in: [src/components/Item.ts:4](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L4)
 
 #### Inherited from
 
@@ -144,7 +144,7 @@ Defined in: [src/components/Item.ts:4](https://github.com/shdwmtr/plugutil/blob/
 optional layout: "below" | "inline";
 ```
 
-Defined in: [src/components/Item.ts:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L7)
+Defined in: [src/components/Item.ts:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L7)
 
 #### Inherited from
 
@@ -158,7 +158,7 @@ Defined in: [src/components/Item.ts:7](https://github.com/shdwmtr/plugutil/blob/
 optional nProgress: number;
 ```
 
-Defined in: [src/components/ProgressBar.ts:10](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ProgressBar.ts#L10)
+Defined in: [src/components/ProgressBar.ts:10](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ProgressBar.ts#L10)
 
 #### Inherited from
 
@@ -172,7 +172,7 @@ Defined in: [src/components/ProgressBar.ts:10](https://github.com/shdwmtr/plugut
 optional nTransitionSec: number;
 ```
 
-Defined in: [src/components/ProgressBar.ts:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ProgressBar.ts#L9)
+Defined in: [src/components/ProgressBar.ts:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ProgressBar.ts#L9)
 
 #### Inherited from
 
@@ -186,7 +186,7 @@ Defined in: [src/components/ProgressBar.ts:9](https://github.com/shdwmtr/pluguti
 optional sOperationText: ReactNode;
 ```
 
-Defined in: [src/components/ProgressBar.ts:23](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ProgressBar.ts#L23)
+Defined in: [src/components/ProgressBar.ts:23](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ProgressBar.ts#L23)
 
 ***
 
@@ -196,7 +196,7 @@ Defined in: [src/components/ProgressBar.ts:23](https://github.com/shdwmtr/plugut
 optional sTimeRemaining: ReactNode;
 ```
 
-Defined in: [src/components/ProgressBar.ts:22](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ProgressBar.ts#L22)
+Defined in: [src/components/ProgressBar.ts:22](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ProgressBar.ts#L22)
 
 ***
 
@@ -206,7 +206,7 @@ Defined in: [src/components/ProgressBar.ts:22](https://github.com/shdwmtr/plugut
 optional tooltip: string;
 ```
 
-Defined in: [src/components/Item.ts:11](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L11)
+Defined in: [src/components/Item.ts:11](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L11)
 
 #### Inherited from
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/Router.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/Router.md
@@ -4,7 +4,7 @@
 
 # Interface: Router
 
-Defined in: [src/modules/Router.ts:89](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L89)
+Defined in: [src/modules/Router.ts:89](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L89)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/modules/Router.ts:89](https://github.com/shdwmtr/plugutil/blob/
 optional WindowStore: WindowStore;
 ```
 
-Defined in: [src/modules/Router.ts:90](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L90)
+Defined in: [src/modules/Router.ts:90](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L90)
 
 ## Accessors
 
@@ -26,7 +26,7 @@ Defined in: [src/modules/Router.ts:90](https://github.com/shdwmtr/plugutil/blob/
 get MainRunningApp(): undefined | AppOverview
 ```
 
-Defined in: [src/modules/Router.ts:101](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L101)
+Defined in: [src/modules/Router.ts:101](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L101)
 
 ##### Returns
 
@@ -42,7 +42,7 @@ Defined in: [src/modules/Router.ts:101](https://github.com/shdwmtr/plugutil/blob
 get RunningApps(): AppOverview[]
 ```
 
-Defined in: [src/modules/Router.ts:100](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L100)
+Defined in: [src/modules/Router.ts:100](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L100)
 
 ##### Returns
 
@@ -56,7 +56,7 @@ Defined in: [src/modules/Router.ts:100](https://github.com/shdwmtr/plugutil/blob
 CloseSideMenus(): void
 ```
 
-Defined in: [src/modules/Router.ts:91](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L91)
+Defined in: [src/modules/Router.ts:91](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L91)
 
 #### Returns
 
@@ -70,7 +70,7 @@ Defined in: [src/modules/Router.ts:91](https://github.com/shdwmtr/plugutil/blob/
 Navigate(path: string): void
 ```
 
-Defined in: [src/modules/Router.ts:92](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L92)
+Defined in: [src/modules/Router.ts:92](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L92)
 
 #### Parameters
 
@@ -90,7 +90,7 @@ Defined in: [src/modules/Router.ts:92](https://github.com/shdwmtr/plugutil/blob/
 NavigateToAppProperties(): void
 ```
 
-Defined in: [src/modules/Router.ts:93](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L93)
+Defined in: [src/modules/Router.ts:93](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L93)
 
 #### Returns
 
@@ -104,7 +104,7 @@ Defined in: [src/modules/Router.ts:93](https://github.com/shdwmtr/plugutil/blob/
 NavigateToChat(): void
 ```
 
-Defined in: [src/modules/Router.ts:96](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L96)
+Defined in: [src/modules/Router.ts:96](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L96)
 
 #### Returns
 
@@ -118,7 +118,7 @@ Defined in: [src/modules/Router.ts:96](https://github.com/shdwmtr/plugutil/blob/
 NavigateToExternalWeb(url: string): void
 ```
 
-Defined in: [src/modules/Router.ts:94](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L94)
+Defined in: [src/modules/Router.ts:94](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L94)
 
 #### Parameters
 
@@ -138,7 +138,7 @@ Defined in: [src/modules/Router.ts:94](https://github.com/shdwmtr/plugutil/blob/
 NavigateToInvites(): void
 ```
 
-Defined in: [src/modules/Router.ts:95](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L95)
+Defined in: [src/modules/Router.ts:95](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L95)
 
 #### Returns
 
@@ -152,7 +152,7 @@ Defined in: [src/modules/Router.ts:95](https://github.com/shdwmtr/plugutil/blob/
 NavigateToLayoutPreview(e: unknown): void
 ```
 
-Defined in: [src/modules/Router.ts:98](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L98)
+Defined in: [src/modules/Router.ts:98](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L98)
 
 #### Parameters
 
@@ -172,7 +172,7 @@ Defined in: [src/modules/Router.ts:98](https://github.com/shdwmtr/plugutil/blob/
 NavigateToLibraryTab(): void
 ```
 
-Defined in: [src/modules/Router.ts:97](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L97)
+Defined in: [src/modules/Router.ts:97](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L97)
 
 #### Returns
 
@@ -186,7 +186,7 @@ Defined in: [src/modules/Router.ts:97](https://github.com/shdwmtr/plugutil/blob/
 OpenPowerMenu(unknown?: any): void
 ```
 
-Defined in: [src/modules/Router.ts:99](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L99)
+Defined in: [src/modules/Router.ts:99](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L99)
 
 #### Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/ShowModalProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/ShowModalProps.md
@@ -4,7 +4,7 @@
 
 # Interface: ShowModalProps
 
-Defined in: [src/components/Modal.tsx:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L7)
+Defined in: [src/components/Modal.tsx:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L7)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/components/Modal.tsx:7](https://github.com/shdwmtr/plugutil/blo
 optional bForcePopOut: boolean;
 ```
 
-Defined in: [src/components/Modal.tsx:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L9)
+Defined in: [src/components/Modal.tsx:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L9)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/components/Modal.tsx:9](https://github.com/shdwmtr/plugutil/blo
 optional bHideActionIcons: boolean;
 ```
 
-Defined in: [src/components/Modal.tsx:10](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L10)
+Defined in: [src/components/Modal.tsx:10](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L10)
 
 ***
 
@@ -34,7 +34,7 @@ Defined in: [src/components/Modal.tsx:10](https://github.com/shdwmtr/plugutil/bl
 optional bHideMainWindowForPopouts: boolean;
 ```
 
-Defined in: [src/components/Modal.tsx:11](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L11)
+Defined in: [src/components/Modal.tsx:11](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L11)
 
 ***
 
@@ -44,7 +44,7 @@ Defined in: [src/components/Modal.tsx:11](https://github.com/shdwmtr/plugutil/bl
 optional bNeverPopOut: boolean;
 ```
 
-Defined in: [src/components/Modal.tsx:12](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L12)
+Defined in: [src/components/Modal.tsx:12](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L12)
 
 ***
 
@@ -54,7 +54,7 @@ Defined in: [src/components/Modal.tsx:12](https://github.com/shdwmtr/plugutil/bl
 optional browserContext: unknown;
 ```
 
-Defined in: [src/components/Modal.tsx:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L8)
+Defined in: [src/components/Modal.tsx:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L8)
 
 ***
 
@@ -64,7 +64,7 @@ Defined in: [src/components/Modal.tsx:8](https://github.com/shdwmtr/plugutil/blo
 optional fnOnClose: () => void;
 ```
 
-Defined in: [src/components/Modal.tsx:13](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L13)
+Defined in: [src/components/Modal.tsx:13](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L13)
 
 #### Returns
 
@@ -78,7 +78,7 @@ Defined in: [src/components/Modal.tsx:13](https://github.com/shdwmtr/plugutil/bl
 optional popupHeight: number;
 ```
 
-Defined in: [src/components/Modal.tsx:14](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L14)
+Defined in: [src/components/Modal.tsx:14](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L14)
 
 ***
 
@@ -88,7 +88,7 @@ Defined in: [src/components/Modal.tsx:14](https://github.com/shdwmtr/plugutil/bl
 optional popupWidth: number;
 ```
 
-Defined in: [src/components/Modal.tsx:15](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L15)
+Defined in: [src/components/Modal.tsx:15](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L15)
 
 ***
 
@@ -98,7 +98,7 @@ Defined in: [src/components/Modal.tsx:15](https://github.com/shdwmtr/plugutil/bl
 optional promiseRenderComplete: Promise<void>;
 ```
 
-Defined in: [src/components/Modal.tsx:16](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L16)
+Defined in: [src/components/Modal.tsx:16](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L16)
 
 ***
 
@@ -108,4 +108,4 @@ Defined in: [src/components/Modal.tsx:16](https://github.com/shdwmtr/plugutil/bl
 optional strTitle: string;
 ```
 
-Defined in: [src/components/Modal.tsx:17](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L17)
+Defined in: [src/components/Modal.tsx:17](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L17)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/ShowModalResult.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/ShowModalResult.md
@@ -4,7 +4,7 @@
 
 # Interface: ShowModalResult
 
-Defined in: [src/components/Modal.tsx:20](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L20)
+Defined in: [src/components/Modal.tsx:20](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L20)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/components/Modal.tsx:20](https://github.com/shdwmtr/plugutil/bl
 Close: () => void;
 ```
 
-Defined in: [src/components/Modal.tsx:22](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L22)
+Defined in: [src/components/Modal.tsx:22](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L22)
 
 #### Returns
 
@@ -28,7 +28,7 @@ Defined in: [src/components/Modal.tsx:22](https://github.com/shdwmtr/plugutil/bl
 Update: (modal: ReactNode) => void;
 ```
 
-Defined in: [src/components/Modal.tsx:29](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L29)
+Defined in: [src/components/Modal.tsx:29](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L29)
 
 #### Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/SidebarNavigationPage.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/SidebarNavigationPage.md
@@ -4,7 +4,7 @@
 
 # Interface: SidebarNavigationPage
 
-Defined in: [src/components/SidebarNavigation.ts:6](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SidebarNavigation.ts#L6)
+Defined in: [src/components/SidebarNavigation.ts:6](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SidebarNavigation.ts#L6)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/components/SidebarNavigation.ts:6](https://github.com/shdwmtr/p
 content: ReactNode;
 ```
 
-Defined in: [src/components/SidebarNavigation.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SidebarNavigation.ts#L8)
+Defined in: [src/components/SidebarNavigation.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SidebarNavigation.ts#L8)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/components/SidebarNavigation.ts:8](https://github.com/shdwmtr/p
 optional hideTitle: boolean;
 ```
 
-Defined in: [src/components/SidebarNavigation.ts:11](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SidebarNavigation.ts#L11)
+Defined in: [src/components/SidebarNavigation.ts:11](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SidebarNavigation.ts#L11)
 
 ***
 
@@ -34,7 +34,7 @@ Defined in: [src/components/SidebarNavigation.ts:11](https://github.com/shdwmtr/
 optional icon: ReactNode;
 ```
 
-Defined in: [src/components/SidebarNavigation.ts:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SidebarNavigation.ts#L9)
+Defined in: [src/components/SidebarNavigation.ts:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SidebarNavigation.ts#L9)
 
 ***
 
@@ -44,7 +44,7 @@ Defined in: [src/components/SidebarNavigation.ts:9](https://github.com/shdwmtr/p
 optional identifier: string;
 ```
 
-Defined in: [src/components/SidebarNavigation.ts:12](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SidebarNavigation.ts#L12)
+Defined in: [src/components/SidebarNavigation.ts:12](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SidebarNavigation.ts#L12)
 
 ***
 
@@ -54,7 +54,7 @@ Defined in: [src/components/SidebarNavigation.ts:12](https://github.com/shdwmtr/
 optional link: string;
 ```
 
-Defined in: [src/components/SidebarNavigation.ts:14](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SidebarNavigation.ts#L14)
+Defined in: [src/components/SidebarNavigation.ts:14](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SidebarNavigation.ts#L14)
 
 ***
 
@@ -64,7 +64,7 @@ Defined in: [src/components/SidebarNavigation.ts:14](https://github.com/shdwmtr/
 optional padding: "none" | "compact";
 ```
 
-Defined in: [src/components/SidebarNavigation.ts:15](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SidebarNavigation.ts#L15)
+Defined in: [src/components/SidebarNavigation.ts:15](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SidebarNavigation.ts#L15)
 
 ***
 
@@ -74,7 +74,7 @@ Defined in: [src/components/SidebarNavigation.ts:15](https://github.com/shdwmtr/
 optional route: string;
 ```
 
-Defined in: [src/components/SidebarNavigation.ts:13](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SidebarNavigation.ts#L13)
+Defined in: [src/components/SidebarNavigation.ts:13](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SidebarNavigation.ts#L13)
 
 ***
 
@@ -84,7 +84,7 @@ Defined in: [src/components/SidebarNavigation.ts:13](https://github.com/shdwmtr/
 title: ReactNode;
 ```
 
-Defined in: [src/components/SidebarNavigation.ts:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SidebarNavigation.ts#L7)
+Defined in: [src/components/SidebarNavigation.ts:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SidebarNavigation.ts#L7)
 
 ***
 
@@ -94,4 +94,4 @@ Defined in: [src/components/SidebarNavigation.ts:7](https://github.com/shdwmtr/p
 optional visible: boolean;
 ```
 
-Defined in: [src/components/SidebarNavigation.ts:10](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SidebarNavigation.ts#L10)
+Defined in: [src/components/SidebarNavigation.ts:10](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SidebarNavigation.ts#L10)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/SidebarNavigationProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/SidebarNavigationProps.md
@@ -4,7 +4,7 @@
 
 # Interface: SidebarNavigationProps
 
-Defined in: [src/components/SidebarNavigation.ts:18](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SidebarNavigation.ts#L18)
+Defined in: [src/components/SidebarNavigation.ts:18](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SidebarNavigation.ts#L18)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/components/SidebarNavigation.ts:18](https://github.com/shdwmtr/
 optional disableRouteReporting: boolean;
 ```
 
-Defined in: [src/components/SidebarNavigation.ts:22](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SidebarNavigation.ts#L22)
+Defined in: [src/components/SidebarNavigation.ts:22](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SidebarNavigation.ts#L22)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/components/SidebarNavigation.ts:22](https://github.com/shdwmtr/
 optional onPageRequested: (page: string) => void;
 ```
 
-Defined in: [src/components/SidebarNavigation.ts:24](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SidebarNavigation.ts#L24)
+Defined in: [src/components/SidebarNavigation.ts:24](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SidebarNavigation.ts#L24)
 
 #### Parameters
 
@@ -44,7 +44,7 @@ Defined in: [src/components/SidebarNavigation.ts:24](https://github.com/shdwmtr/
 optional page: string;
 ```
 
-Defined in: [src/components/SidebarNavigation.ts:23](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SidebarNavigation.ts#L23)
+Defined in: [src/components/SidebarNavigation.ts:23](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SidebarNavigation.ts#L23)
 
 ***
 
@@ -54,7 +54,7 @@ Defined in: [src/components/SidebarNavigation.ts:23](https://github.com/shdwmtr/
 pages: (SidebarNavigationPage | "separator")[];
 ```
 
-Defined in: [src/components/SidebarNavigation.ts:20](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SidebarNavigation.ts#L20)
+Defined in: [src/components/SidebarNavigation.ts:20](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SidebarNavigation.ts#L20)
 
 ***
 
@@ -64,7 +64,7 @@ Defined in: [src/components/SidebarNavigation.ts:20](https://github.com/shdwmtr/
 optional showTitle: boolean;
 ```
 
-Defined in: [src/components/SidebarNavigation.ts:21](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SidebarNavigation.ts#L21)
+Defined in: [src/components/SidebarNavigation.ts:21](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SidebarNavigation.ts#L21)
 
 ***
 
@@ -74,4 +74,4 @@ Defined in: [src/components/SidebarNavigation.ts:21](https://github.com/shdwmtr/
 optional title: string;
 ```
 
-Defined in: [src/components/SidebarNavigation.ts:19](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SidebarNavigation.ts#L19)
+Defined in: [src/components/SidebarNavigation.ts:19](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SidebarNavigation.ts#L19)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/SimpleModalProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/SimpleModalProps.md
@@ -4,7 +4,7 @@
 
 # Interface: SimpleModalProps
 
-Defined in: [src/components/Modal.tsx:107](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L107)
+Defined in: [src/components/Modal.tsx:107](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L107)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/components/Modal.tsx:107](https://github.com/shdwmtr/plugutil/b
 optional active: boolean;
 ```
 
-Defined in: [src/components/Modal.tsx:108](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L108)
+Defined in: [src/components/Modal.tsx:108](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L108)
 
 ***
 
@@ -24,4 +24,4 @@ Defined in: [src/components/Modal.tsx:108](https://github.com/shdwmtr/plugutil/b
 children: ReactNode;
 ```
 
-Defined in: [src/components/Modal.tsx:109](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Modal.tsx#L109)
+Defined in: [src/components/Modal.tsx:109](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Modal.tsx#L109)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/SingleDropdownOption.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/SingleDropdownOption.md
@@ -4,7 +4,7 @@
 
 # Interface: SingleDropdownOption
 
-Defined in: [src/components/Dropdown.ts:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L7)
+Defined in: [src/components/Dropdown.ts:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L7)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/components/Dropdown.ts:7](https://github.com/shdwmtr/plugutil/b
 data: any;
 ```
 
-Defined in: [src/components/Dropdown.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L8)
+Defined in: [src/components/Dropdown.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L8)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/components/Dropdown.ts:8](https://github.com/shdwmtr/plugutil/b
 label: ReactNode;
 ```
 
-Defined in: [src/components/Dropdown.ts:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L9)
+Defined in: [src/components/Dropdown.ts:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L9)
 
 ***
 
@@ -34,4 +34,4 @@ Defined in: [src/components/Dropdown.ts:9](https://github.com/shdwmtr/plugutil/b
 optional options: undefined;
 ```
 
-Defined in: [src/components/Dropdown.ts:11](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L11)
+Defined in: [src/components/Dropdown.ts:11](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L11)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/SliderFieldProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/SliderFieldProps.md
@@ -4,7 +4,7 @@
 
 # Interface: SliderFieldProps
 
-Defined in: [src/components/SliderField.ts:12](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SliderField.ts#L12)
+Defined in: [src/components/SliderField.ts:12](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SliderField.ts#L12)
 
 ## Extends
 
@@ -18,7 +18,7 @@ Defined in: [src/components/SliderField.ts:12](https://github.com/shdwmtr/plugut
 optional bottomSeparator: "standard" | "thick" | "none";
 ```
 
-Defined in: [src/components/Item.ts:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L9)
+Defined in: [src/components/Item.ts:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L9)
 
 #### Inherited from
 
@@ -34,7 +34,7 @@ ItemProps.bottomSeparator
 optional children: ReactNode;
 ```
 
-Defined in: [src/components/Item.ts:6](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L6)
+Defined in: [src/components/Item.ts:6](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L6)
 
 #### Inherited from
 
@@ -50,7 +50,7 @@ ItemProps.children
 optional className: string;
 ```
 
-Defined in: [src/components/SliderField.ts:28](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SliderField.ts#L28)
+Defined in: [src/components/SliderField.ts:28](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SliderField.ts#L28)
 
 ***
 
@@ -60,7 +60,7 @@ Defined in: [src/components/SliderField.ts:28](https://github.com/shdwmtr/plugut
 optional description: ReactNode;
 ```
 
-Defined in: [src/components/Item.ts:5](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L5)
+Defined in: [src/components/Item.ts:5](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L5)
 
 #### Inherited from
 
@@ -76,7 +76,7 @@ ItemProps.description
 optional disabled: boolean;
 ```
 
-Defined in: [src/components/SliderField.ts:22](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SliderField.ts#L22)
+Defined in: [src/components/SliderField.ts:22](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SliderField.ts#L22)
 
 ***
 
@@ -86,7 +86,7 @@ Defined in: [src/components/SliderField.ts:22](https://github.com/shdwmtr/plugut
 optional editableValue: boolean;
 ```
 
-Defined in: [src/components/SliderField.ts:23](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SliderField.ts#L23)
+Defined in: [src/components/SliderField.ts:23](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SliderField.ts#L23)
 
 ***
 
@@ -96,7 +96,7 @@ Defined in: [src/components/SliderField.ts:23](https://github.com/shdwmtr/plugut
 optional highlightOnFocus: boolean;
 ```
 
-Defined in: [src/components/Item.ts:12](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L12)
+Defined in: [src/components/Item.ts:12](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L12)
 
 #### Inherited from
 
@@ -112,7 +112,7 @@ ItemProps.highlightOnFocus
 optional icon: ReactNode;
 ```
 
-Defined in: [src/components/Item.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L8)
+Defined in: [src/components/Item.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L8)
 
 #### Inherited from
 
@@ -128,7 +128,7 @@ ItemProps.icon
 optional indentLevel: number;
 ```
 
-Defined in: [src/components/Item.ts:10](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L10)
+Defined in: [src/components/Item.ts:10](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L10)
 
 #### Inherited from
 
@@ -144,7 +144,7 @@ ItemProps.indentLevel
 optional label: ReactNode;
 ```
 
-Defined in: [src/components/Item.ts:4](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L4)
+Defined in: [src/components/Item.ts:4](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L4)
 
 #### Inherited from
 
@@ -160,7 +160,7 @@ ItemProps.label
 optional layout: "below" | "inline";
 ```
 
-Defined in: [src/components/Item.ts:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L7)
+Defined in: [src/components/Item.ts:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L7)
 
 #### Inherited from
 
@@ -176,7 +176,7 @@ ItemProps.layout
 optional max: number;
 ```
 
-Defined in: [src/components/SliderField.ts:15](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SliderField.ts#L15)
+Defined in: [src/components/SliderField.ts:15](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SliderField.ts#L15)
 
 ***
 
@@ -186,7 +186,7 @@ Defined in: [src/components/SliderField.ts:15](https://github.com/shdwmtr/plugut
 optional min: number;
 ```
 
-Defined in: [src/components/SliderField.ts:14](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SliderField.ts#L14)
+Defined in: [src/components/SliderField.ts:14](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SliderField.ts#L14)
 
 ***
 
@@ -196,7 +196,7 @@ Defined in: [src/components/SliderField.ts:14](https://github.com/shdwmtr/plugut
 optional minimumDpadGranularity: number;
 ```
 
-Defined in: [src/components/SliderField.ts:26](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SliderField.ts#L26)
+Defined in: [src/components/SliderField.ts:26](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SliderField.ts#L26)
 
 ***
 
@@ -206,7 +206,7 @@ Defined in: [src/components/SliderField.ts:26](https://github.com/shdwmtr/plugut
 optional notchCount: number;
 ```
 
-Defined in: [src/components/SliderField.ts:17](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SliderField.ts#L17)
+Defined in: [src/components/SliderField.ts:17](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SliderField.ts#L17)
 
 ***
 
@@ -216,7 +216,7 @@ Defined in: [src/components/SliderField.ts:17](https://github.com/shdwmtr/plugut
 optional notchLabels: NotchLabel[];
 ```
 
-Defined in: [src/components/SliderField.ts:18](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SliderField.ts#L18)
+Defined in: [src/components/SliderField.ts:18](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SliderField.ts#L18)
 
 ***
 
@@ -226,7 +226,7 @@ Defined in: [src/components/SliderField.ts:18](https://github.com/shdwmtr/plugut
 optional notchTicksVisible: boolean;
 ```
 
-Defined in: [src/components/SliderField.ts:19](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SliderField.ts#L19)
+Defined in: [src/components/SliderField.ts:19](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SliderField.ts#L19)
 
 ***
 
@@ -236,7 +236,7 @@ Defined in: [src/components/SliderField.ts:19](https://github.com/shdwmtr/plugut
 optional resetValue: number;
 ```
 
-Defined in: [src/components/SliderField.ts:21](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SliderField.ts#L21)
+Defined in: [src/components/SliderField.ts:21](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SliderField.ts#L21)
 
 ***
 
@@ -246,7 +246,7 @@ Defined in: [src/components/SliderField.ts:21](https://github.com/shdwmtr/plugut
 optional showValue: boolean;
 ```
 
-Defined in: [src/components/SliderField.ts:20](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SliderField.ts#L20)
+Defined in: [src/components/SliderField.ts:20](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SliderField.ts#L20)
 
 ***
 
@@ -256,7 +256,7 @@ Defined in: [src/components/SliderField.ts:20](https://github.com/shdwmtr/plugut
 optional step: number;
 ```
 
-Defined in: [src/components/SliderField.ts:16](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SliderField.ts#L16)
+Defined in: [src/components/SliderField.ts:16](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SliderField.ts#L16)
 
 ***
 
@@ -266,7 +266,7 @@ Defined in: [src/components/SliderField.ts:16](https://github.com/shdwmtr/plugut
 optional tooltip: string;
 ```
 
-Defined in: [src/components/Item.ts:11](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L11)
+Defined in: [src/components/Item.ts:11](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L11)
 
 #### Inherited from
 
@@ -282,7 +282,7 @@ ItemProps.tooltip
 optional validValues: "steps" | "range" | (value: number) => boolean;
 ```
 
-Defined in: [src/components/SliderField.ts:24](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SliderField.ts#L24)
+Defined in: [src/components/SliderField.ts:24](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SliderField.ts#L24)
 
 ***
 
@@ -292,7 +292,7 @@ Defined in: [src/components/SliderField.ts:24](https://github.com/shdwmtr/plugut
 value: number;
 ```
 
-Defined in: [src/components/SliderField.ts:13](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SliderField.ts#L13)
+Defined in: [src/components/SliderField.ts:13](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SliderField.ts#L13)
 
 ***
 
@@ -302,7 +302,7 @@ Defined in: [src/components/SliderField.ts:13](https://github.com/shdwmtr/plugut
 optional valueSuffix: string;
 ```
 
-Defined in: [src/components/SliderField.ts:25](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SliderField.ts#L25)
+Defined in: [src/components/SliderField.ts:25](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SliderField.ts#L25)
 
 ## Methods
 
@@ -312,7 +312,7 @@ Defined in: [src/components/SliderField.ts:25](https://github.com/shdwmtr/plugut
 optional onChange(value: number): void
 ```
 
-Defined in: [src/components/SliderField.ts:27](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SliderField.ts#L27)
+Defined in: [src/components/SliderField.ts:27](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SliderField.ts#L27)
 
 #### Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/SteamAppOverview.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/SteamAppOverview.md
@@ -4,7 +4,7 @@
 
 # Interface: SteamAppOverview
 
-Defined in: [src/globals/SteamClient.ts:312](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L312)
+Defined in: [src/globals/SteamClient.ts:312](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L312)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/globals/SteamClient.ts:312](https://github.com/shdwmtr/plugutil
 appid: number;
 ```
 
-Defined in: [src/globals/SteamClient.ts:315](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L315)
+Defined in: [src/globals/SteamClient.ts:315](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L315)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/globals/SteamClient.ts:315](https://github.com/shdwmtr/plugutil
 BIsModOrShortcut: () => boolean;
 ```
 
-Defined in: [src/globals/SteamClient.ts:319](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L319)
+Defined in: [src/globals/SteamClient.ts:319](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L319)
 
 #### Returns
 
@@ -38,7 +38,7 @@ Defined in: [src/globals/SteamClient.ts:319](https://github.com/shdwmtr/plugutil
 BIsShortcut: () => boolean;
 ```
 
-Defined in: [src/globals/SteamClient.ts:320](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L320)
+Defined in: [src/globals/SteamClient.ts:320](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L320)
 
 #### Returns
 
@@ -52,7 +52,7 @@ Defined in: [src/globals/SteamClient.ts:320](https://github.com/shdwmtr/plugutil
 display_name: string;
 ```
 
-Defined in: [src/globals/SteamClient.ts:313](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L313)
+Defined in: [src/globals/SteamClient.ts:313](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L313)
 
 ***
 
@@ -62,7 +62,7 @@ Defined in: [src/globals/SteamClient.ts:313](https://github.com/shdwmtr/plugutil
 gameid: string;
 ```
 
-Defined in: [src/globals/SteamClient.ts:314](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L314)
+Defined in: [src/globals/SteamClient.ts:314](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L314)
 
 ***
 
@@ -72,7 +72,7 @@ Defined in: [src/globals/SteamClient.ts:314](https://github.com/shdwmtr/plugutil
 icon_hash: string;
 ```
 
-Defined in: [src/globals/SteamClient.ts:316](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L316)
+Defined in: [src/globals/SteamClient.ts:316](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L316)
 
 ***
 
@@ -82,7 +82,7 @@ Defined in: [src/globals/SteamClient.ts:316](https://github.com/shdwmtr/plugutil
 optional selected_clientid: string;
 ```
 
-Defined in: [src/globals/SteamClient.ts:318](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L318)
+Defined in: [src/globals/SteamClient.ts:318](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L318)
 
 ***
 
@@ -92,4 +92,4 @@ Defined in: [src/globals/SteamClient.ts:318](https://github.com/shdwmtr/plugutil
 optional third_party_mod: boolean;
 ```
 
-Defined in: [src/globals/SteamClient.ts:317](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L317)
+Defined in: [src/globals/SteamClient.ts:317](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L317)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/SteamClient.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/SteamClient.md
@@ -4,7 +4,7 @@
 
 # Interface: SteamClient
 
-Defined in: [src/globals/SteamClient.ts:151](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L151)
+Defined in: [src/globals/SteamClient.ts:151](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L151)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/globals/SteamClient.ts:151](https://github.com/shdwmtr/plugutil
 Apps: Apps;
 ```
 
-Defined in: [src/globals/SteamClient.ts:152](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L152)
+Defined in: [src/globals/SteamClient.ts:152](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L152)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/globals/SteamClient.ts:152](https://github.com/shdwmtr/plugutil
 Browser: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:153](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L153)
+Defined in: [src/globals/SteamClient.ts:153](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L153)
 
 ***
 
@@ -34,7 +34,7 @@ Defined in: [src/globals/SteamClient.ts:153](https://github.com/shdwmtr/plugutil
 BrowserView: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:154](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L154)
+Defined in: [src/globals/SteamClient.ts:154](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L154)
 
 ***
 
@@ -44,7 +44,7 @@ Defined in: [src/globals/SteamClient.ts:154](https://github.com/shdwmtr/plugutil
 ClientNotifications: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:155](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L155)
+Defined in: [src/globals/SteamClient.ts:155](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L155)
 
 ***
 
@@ -54,7 +54,7 @@ Defined in: [src/globals/SteamClient.ts:155](https://github.com/shdwmtr/plugutil
 Cloud: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:156](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L156)
+Defined in: [src/globals/SteamClient.ts:156](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L156)
 
 ***
 
@@ -64,7 +64,7 @@ Defined in: [src/globals/SteamClient.ts:156](https://github.com/shdwmtr/plugutil
 Console: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:157](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L157)
+Defined in: [src/globals/SteamClient.ts:157](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L157)
 
 ***
 
@@ -74,7 +74,7 @@ Defined in: [src/globals/SteamClient.ts:157](https://github.com/shdwmtr/plugutil
 Downloads: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:158](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L158)
+Defined in: [src/globals/SteamClient.ts:158](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L158)
 
 ***
 
@@ -84,7 +84,7 @@ Defined in: [src/globals/SteamClient.ts:158](https://github.com/shdwmtr/plugutil
 FamilySharing: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:159](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L159)
+Defined in: [src/globals/SteamClient.ts:159](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L159)
 
 ***
 
@@ -94,7 +94,7 @@ Defined in: [src/globals/SteamClient.ts:159](https://github.com/shdwmtr/plugutil
 Friends: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:161](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L161)
+Defined in: [src/globals/SteamClient.ts:161](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L161)
 
 ***
 
@@ -104,7 +104,7 @@ Defined in: [src/globals/SteamClient.ts:161](https://github.com/shdwmtr/plugutil
 FriendSettings: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:160](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L160)
+Defined in: [src/globals/SteamClient.ts:160](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L160)
 
 ***
 
@@ -114,7 +114,7 @@ Defined in: [src/globals/SteamClient.ts:160](https://github.com/shdwmtr/plugutil
 GameSessions: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:162](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L162)
+Defined in: [src/globals/SteamClient.ts:162](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L162)
 
 ***
 
@@ -124,7 +124,7 @@ Defined in: [src/globals/SteamClient.ts:162](https://github.com/shdwmtr/plugutil
 Input: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:163](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L163)
+Defined in: [src/globals/SteamClient.ts:163](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L163)
 
 ***
 
@@ -134,7 +134,7 @@ Defined in: [src/globals/SteamClient.ts:163](https://github.com/shdwmtr/plugutil
 InstallFolder: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:164](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L164)
+Defined in: [src/globals/SteamClient.ts:164](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L164)
 
 ***
 
@@ -144,7 +144,7 @@ Defined in: [src/globals/SteamClient.ts:164](https://github.com/shdwmtr/plugutil
 Installs: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:165](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L165)
+Defined in: [src/globals/SteamClient.ts:165](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L165)
 
 ***
 
@@ -154,7 +154,7 @@ Defined in: [src/globals/SteamClient.ts:165](https://github.com/shdwmtr/plugutil
 MachineStorage: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:166](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L166)
+Defined in: [src/globals/SteamClient.ts:166](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L166)
 
 ***
 
@@ -164,7 +164,7 @@ Defined in: [src/globals/SteamClient.ts:166](https://github.com/shdwmtr/plugutil
 Messaging: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:167](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L167)
+Defined in: [src/globals/SteamClient.ts:167](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L167)
 
 ***
 
@@ -174,7 +174,7 @@ Defined in: [src/globals/SteamClient.ts:167](https://github.com/shdwmtr/plugutil
 Notifications: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:168](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L168)
+Defined in: [src/globals/SteamClient.ts:168](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L168)
 
 ***
 
@@ -184,7 +184,7 @@ Defined in: [src/globals/SteamClient.ts:168](https://github.com/shdwmtr/plugutil
 OpenVR: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:169](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L169)
+Defined in: [src/globals/SteamClient.ts:169](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L169)
 
 ***
 
@@ -194,7 +194,7 @@ Defined in: [src/globals/SteamClient.ts:169](https://github.com/shdwmtr/plugutil
 Overlay: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:170](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L170)
+Defined in: [src/globals/SteamClient.ts:170](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L170)
 
 ***
 
@@ -204,7 +204,7 @@ Defined in: [src/globals/SteamClient.ts:170](https://github.com/shdwmtr/plugutil
 Parental: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:171](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L171)
+Defined in: [src/globals/SteamClient.ts:171](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L171)
 
 ***
 
@@ -214,7 +214,7 @@ Defined in: [src/globals/SteamClient.ts:171](https://github.com/shdwmtr/plugutil
 RegisterIFrameNavigatedCallback: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:172](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L172)
+Defined in: [src/globals/SteamClient.ts:172](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L172)
 
 ***
 
@@ -224,7 +224,7 @@ Defined in: [src/globals/SteamClient.ts:172](https://github.com/shdwmtr/plugutil
 RemotePlay: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:173](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L173)
+Defined in: [src/globals/SteamClient.ts:173](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L173)
 
 ***
 
@@ -234,7 +234,7 @@ Defined in: [src/globals/SteamClient.ts:173](https://github.com/shdwmtr/plugutil
 RoamingStorage: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:174](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L174)
+Defined in: [src/globals/SteamClient.ts:174](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L174)
 
 ***
 
@@ -244,7 +244,7 @@ Defined in: [src/globals/SteamClient.ts:174](https://github.com/shdwmtr/plugutil
 Screenshots: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:175](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L175)
+Defined in: [src/globals/SteamClient.ts:175](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L175)
 
 ***
 
@@ -254,7 +254,7 @@ Defined in: [src/globals/SteamClient.ts:175](https://github.com/shdwmtr/plugutil
 Settings: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:176](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L176)
+Defined in: [src/globals/SteamClient.ts:176](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L176)
 
 ***
 
@@ -264,7 +264,7 @@ Defined in: [src/globals/SteamClient.ts:176](https://github.com/shdwmtr/plugutil
 SharedConnection: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:177](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L177)
+Defined in: [src/globals/SteamClient.ts:177](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L177)
 
 ***
 
@@ -274,7 +274,7 @@ Defined in: [src/globals/SteamClient.ts:177](https://github.com/shdwmtr/plugutil
 Stats: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:178](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L178)
+Defined in: [src/globals/SteamClient.ts:178](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L178)
 
 ***
 
@@ -284,7 +284,7 @@ Defined in: [src/globals/SteamClient.ts:178](https://github.com/shdwmtr/plugutil
 Storage: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:179](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L179)
+Defined in: [src/globals/SteamClient.ts:179](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L179)
 
 ***
 
@@ -294,7 +294,7 @@ Defined in: [src/globals/SteamClient.ts:179](https://github.com/shdwmtr/plugutil
 Streaming: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:180](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L180)
+Defined in: [src/globals/SteamClient.ts:180](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L180)
 
 ***
 
@@ -304,7 +304,7 @@ Defined in: [src/globals/SteamClient.ts:180](https://github.com/shdwmtr/plugutil
 System: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:181](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L181)
+Defined in: [src/globals/SteamClient.ts:181](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L181)
 
 ***
 
@@ -314,7 +314,7 @@ Defined in: [src/globals/SteamClient.ts:181](https://github.com/shdwmtr/plugutil
 UI: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:182](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L182)
+Defined in: [src/globals/SteamClient.ts:182](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L182)
 
 ***
 
@@ -324,7 +324,7 @@ Defined in: [src/globals/SteamClient.ts:182](https://github.com/shdwmtr/plugutil
 Updates: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:184](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L184)
+Defined in: [src/globals/SteamClient.ts:184](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L184)
 
 ***
 
@@ -334,7 +334,7 @@ Defined in: [src/globals/SteamClient.ts:184](https://github.com/shdwmtr/plugutil
 URL: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:183](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L183)
+Defined in: [src/globals/SteamClient.ts:183](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L183)
 
 ***
 
@@ -344,7 +344,7 @@ Defined in: [src/globals/SteamClient.ts:183](https://github.com/shdwmtr/plugutil
 User: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:185](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L185)
+Defined in: [src/globals/SteamClient.ts:185](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L185)
 
 ***
 
@@ -354,7 +354,7 @@ Defined in: [src/globals/SteamClient.ts:185](https://github.com/shdwmtr/plugutil
 WebChat: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:186](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L186)
+Defined in: [src/globals/SteamClient.ts:186](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L186)
 
 ***
 
@@ -364,4 +364,4 @@ Defined in: [src/globals/SteamClient.ts:186](https://github.com/shdwmtr/plugutil
 Window: Window;
 ```
 
-Defined in: [src/globals/SteamClient.ts:187](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L187)
+Defined in: [src/globals/SteamClient.ts:187](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L187)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/SteamShortcut.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/SteamShortcut.md
@@ -4,7 +4,7 @@
 
 # Interface: SteamShortcut
 
-Defined in: [src/globals/SteamClient.ts:190](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L190)
+Defined in: [src/globals/SteamClient.ts:190](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L190)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/globals/SteamClient.ts:190](https://github.com/shdwmtr/plugutil
 appid: number;
 ```
 
-Defined in: [src/globals/SteamClient.ts:191](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L191)
+Defined in: [src/globals/SteamClient.ts:191](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L191)
 
 ***
 
@@ -31,7 +31,7 @@ data: {
 };
 ```
 
-Defined in: [src/globals/SteamClient.ts:192](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L192)
+Defined in: [src/globals/SteamClient.ts:192](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L192)
 
 #### bIsApplication
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/SteamSpinnerProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/SteamSpinnerProps.md
@@ -4,7 +4,7 @@
 
 # Interface: SteamSpinnerProps
 
-Defined in: [src/components/SteamSpinner.ts:5](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SteamSpinner.ts#L5)
+Defined in: [src/components/SteamSpinner.ts:5](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SteamSpinner.ts#L5)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/components/SteamSpinner.ts:5](https://github.com/shdwmtr/plugut
 optional background: "transparent";
 ```
 
-Defined in: [src/components/SteamSpinner.ts:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SteamSpinner.ts#L7)
+Defined in: [src/components/SteamSpinner.ts:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SteamSpinner.ts#L7)
 
 ***
 
@@ -24,4 +24,4 @@ Defined in: [src/components/SteamSpinner.ts:7](https://github.com/shdwmtr/plugut
 optional children: ReactNode;
 ```
 
-Defined in: [src/components/SteamSpinner.ts:6](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/SteamSpinner.ts#L6)
+Defined in: [src/components/SteamSpinner.ts:6](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/SteamSpinner.ts#L6)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/SuspensefulImageProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/SuspensefulImageProps.md
@@ -4,7 +4,7 @@
 
 # Interface: SuspensefulImageProps
 
-Defined in: [src/custom-components/SuspensefulImage.tsx:6](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/custom-components/SuspensefulImage.tsx#L6)
+Defined in: [src/custom-components/SuspensefulImage.tsx:6](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/custom-components/SuspensefulImage.tsx#L6)
 
 ## Extends
 
@@ -4389,7 +4389,7 @@ ImgHTMLAttributes.suppressHydrationWarning
 optional suspenseHeight: string | number;
 ```
 
-Defined in: [src/custom-components/SuspensefulImage.tsx:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/custom-components/SuspensefulImage.tsx#L8)
+Defined in: [src/custom-components/SuspensefulImage.tsx:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/custom-components/SuspensefulImage.tsx#L8)
 
 ***
 
@@ -4399,7 +4399,7 @@ Defined in: [src/custom-components/SuspensefulImage.tsx:8](https://github.com/sh
 optional suspenseWidth: string | number;
 ```
 
-Defined in: [src/custom-components/SuspensefulImage.tsx:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/custom-components/SuspensefulImage.tsx#L7)
+Defined in: [src/custom-components/SuspensefulImage.tsx:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/custom-components/SuspensefulImage.tsx#L7)
 
 ***
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/Tab.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/Tab.md
@@ -4,7 +4,7 @@
 
 # Interface: Tab
 
-Defined in: [src/components/Tabs.tsx:17](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Tabs.tsx#L17)
+Defined in: [src/components/Tabs.tsx:17](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Tabs.tsx#L17)
 
 Individual tab objects for the Tabs component
 
@@ -22,7 +22,7 @@ Individual tab objects for the Tabs component
 content: ReactNode;
 ```
 
-Defined in: [src/components/Tabs.tsx:21](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Tabs.tsx#L21)
+Defined in: [src/components/Tabs.tsx:21](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Tabs.tsx#L21)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [src/components/Tabs.tsx:21](https://github.com/shdwmtr/plugutil/blo
 optional footer: FooterLegendProps;
 ```
 
-Defined in: [src/components/Tabs.tsx:22](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Tabs.tsx#L22)
+Defined in: [src/components/Tabs.tsx:22](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Tabs.tsx#L22)
 
 ***
 
@@ -42,7 +42,7 @@ Defined in: [src/components/Tabs.tsx:22](https://github.com/shdwmtr/plugutil/blo
 id: string;
 ```
 
-Defined in: [src/components/Tabs.tsx:18](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Tabs.tsx#L18)
+Defined in: [src/components/Tabs.tsx:18](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Tabs.tsx#L18)
 
 ***
 
@@ -52,7 +52,7 @@ Defined in: [src/components/Tabs.tsx:18](https://github.com/shdwmtr/plugutil/blo
 optional renderTabAddon: () => ReactNode;
 ```
 
-Defined in: [src/components/Tabs.tsx:20](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Tabs.tsx#L20)
+Defined in: [src/components/Tabs.tsx:20](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Tabs.tsx#L20)
 
 #### Returns
 
@@ -66,4 +66,4 @@ Defined in: [src/components/Tabs.tsx:20](https://github.com/shdwmtr/plugutil/blo
 title: string;
 ```
 
-Defined in: [src/components/Tabs.tsx:19](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Tabs.tsx#L19)
+Defined in: [src/components/Tabs.tsx:19](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Tabs.tsx#L19)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/TabsProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/TabsProps.md
@@ -4,7 +4,7 @@
 
 # Interface: TabsProps
 
-Defined in: [src/components/Tabs.tsx:61](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Tabs.tsx#L61)
+Defined in: [src/components/Tabs.tsx:61](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Tabs.tsx#L61)
 
 Props for the [Tabs](../functions/Tabs.md)
 
@@ -52,7 +52,7 @@ return (
 activeTab: string;
 ```
 
-Defined in: [src/components/Tabs.tsx:63](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Tabs.tsx#L63)
+Defined in: [src/components/Tabs.tsx:63](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Tabs.tsx#L63)
 
 ***
 
@@ -62,7 +62,7 @@ Defined in: [src/components/Tabs.tsx:63](https://github.com/shdwmtr/plugutil/blo
 optional autoFocusContents: boolean;
 ```
 
-Defined in: [src/components/Tabs.tsx:65](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Tabs.tsx#L65)
+Defined in: [src/components/Tabs.tsx:65](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Tabs.tsx#L65)
 
 ***
 
@@ -72,7 +72,7 @@ Defined in: [src/components/Tabs.tsx:65](https://github.com/shdwmtr/plugutil/blo
 onShowTab: (tab: string) => void;
 ```
 
-Defined in: [src/components/Tabs.tsx:64](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Tabs.tsx#L64)
+Defined in: [src/components/Tabs.tsx:64](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Tabs.tsx#L64)
 
 #### Parameters
 
@@ -92,4 +92,4 @@ Defined in: [src/components/Tabs.tsx:64](https://github.com/shdwmtr/plugutil/blo
 tabs: Tab[];
 ```
 
-Defined in: [src/components/Tabs.tsx:62](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Tabs.tsx#L62)
+Defined in: [src/components/Tabs.tsx:62](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Tabs.tsx#L62)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/TextFieldProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/TextFieldProps.md
@@ -4,7 +4,7 @@
 
 # Interface: TextFieldProps
 
-Defined in: [src/components/TextField.ts:5](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/TextField.ts#L5)
+Defined in: [src/components/TextField.ts:5](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/TextField.ts#L5)
 
 ## Extends
 
@@ -1097,7 +1097,7 @@ HTMLAttributes.autoSave
 optional bAlwaysShowClearAction: boolean;
 ```
 
-Defined in: [src/components/TextField.ts:12](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/TextField.ts#L12)
+Defined in: [src/components/TextField.ts:12](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/TextField.ts#L12)
 
 ***
 
@@ -1107,7 +1107,7 @@ Defined in: [src/components/TextField.ts:12](https://github.com/shdwmtr/plugutil
 optional bIsPassword: boolean;
 ```
 
-Defined in: [src/components/TextField.ts:13](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/TextField.ts#L13)
+Defined in: [src/components/TextField.ts:13](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/TextField.ts#L13)
 
 ***
 
@@ -1117,7 +1117,7 @@ Defined in: [src/components/TextField.ts:13](https://github.com/shdwmtr/plugutil
 optional bShowClearAction: boolean;
 ```
 
-Defined in: [src/components/TextField.ts:11](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/TextField.ts#L11)
+Defined in: [src/components/TextField.ts:11](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/TextField.ts#L11)
 
 ***
 
@@ -1127,7 +1127,7 @@ Defined in: [src/components/TextField.ts:11](https://github.com/shdwmtr/plugutil
 optional bShowCopyAction: boolean;
 ```
 
-Defined in: [src/components/TextField.ts:10](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/TextField.ts#L10)
+Defined in: [src/components/TextField.ts:10](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/TextField.ts#L10)
 
 ***
 
@@ -1289,7 +1289,7 @@ HTMLAttributes.defaultValue
 optional description: ReactNode;
 ```
 
-Defined in: [src/components/TextField.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/TextField.ts#L8)
+Defined in: [src/components/TextField.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/TextField.ts#L8)
 
 ***
 
@@ -1315,7 +1315,7 @@ HTMLAttributes.dir
 optional disabled: boolean;
 ```
 
-Defined in: [src/components/TextField.ts:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/TextField.ts#L9)
+Defined in: [src/components/TextField.ts:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/TextField.ts#L9)
 
 ***
 
@@ -1341,7 +1341,7 @@ HTMLAttributes.draggable
 optional focusOnMount: boolean;
 ```
 
-Defined in: [src/components/TextField.ts:19](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/TextField.ts#L19)
+Defined in: [src/components/TextField.ts:19](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/TextField.ts#L19)
 
 ***
 
@@ -1383,7 +1383,7 @@ HTMLAttributes.id
 optional inlineControls: ReactNode;
 ```
 
-Defined in: [src/components/TextField.ts:21](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/TextField.ts#L21)
+Defined in: [src/components/TextField.ts:21](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/TextField.ts#L21)
 
 ***
 
@@ -1541,7 +1541,7 @@ HTMLAttributes.itemType
 optional label: ReactNode;
 ```
 
-Defined in: [src/components/TextField.ts:6](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/TextField.ts#L6)
+Defined in: [src/components/TextField.ts:6](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/TextField.ts#L6)
 
 ***
 
@@ -1567,7 +1567,7 @@ HTMLAttributes.lang
 optional mustBeEmail: boolean;
 ```
 
-Defined in: [src/components/TextField.ts:18](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/TextField.ts#L18)
+Defined in: [src/components/TextField.ts:18](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/TextField.ts#L18)
 
 ***
 
@@ -1577,7 +1577,7 @@ Defined in: [src/components/TextField.ts:18](https://github.com/shdwmtr/plugutil
 optional mustBeNumeric: boolean;
 ```
 
-Defined in: [src/components/TextField.ts:16](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/TextField.ts#L16)
+Defined in: [src/components/TextField.ts:16](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/TextField.ts#L16)
 
 ***
 
@@ -1587,7 +1587,7 @@ Defined in: [src/components/TextField.ts:16](https://github.com/shdwmtr/plugutil
 optional mustBeURL: boolean;
 ```
 
-Defined in: [src/components/TextField.ts:17](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/TextField.ts#L17)
+Defined in: [src/components/TextField.ts:17](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/TextField.ts#L17)
 
 ***
 
@@ -1885,7 +1885,7 @@ HTMLAttributes.onCanPlayThroughCapture
 optional onChange: ChangeEventHandler<HTMLInputElement>;
 ```
 
-Defined in: [src/components/TextField.ts:22](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/TextField.ts#L22)
+Defined in: [src/components/TextField.ts:22](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/TextField.ts#L22)
 
 #### Overrides
 
@@ -4221,7 +4221,7 @@ HTMLAttributes.radioGroup
 optional rangeMax: number;
 ```
 
-Defined in: [src/components/TextField.ts:15](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/TextField.ts#L15)
+Defined in: [src/components/TextField.ts:15](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/TextField.ts#L15)
 
 ***
 
@@ -4231,7 +4231,7 @@ Defined in: [src/components/TextField.ts:15](https://github.com/shdwmtr/plugutil
 optional rangeMin: number;
 ```
 
-Defined in: [src/components/TextField.ts:14](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/TextField.ts#L14)
+Defined in: [src/components/TextField.ts:14](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/TextField.ts#L14)
 
 ***
 
@@ -4241,7 +4241,7 @@ Defined in: [src/components/TextField.ts:14](https://github.com/shdwmtr/plugutil
 optional requiredLabel: ReactNode;
 ```
 
-Defined in: [src/components/TextField.ts:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/TextField.ts#L7)
+Defined in: [src/components/TextField.ts:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/TextField.ts#L7)
 
 ***
 
@@ -4427,7 +4427,7 @@ HTMLAttributes.title
 optional tooltip: string;
 ```
 
-Defined in: [src/components/TextField.ts:20](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/TextField.ts#L20)
+Defined in: [src/components/TextField.ts:20](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/TextField.ts#L20)
 
 ***
 
@@ -4485,7 +4485,7 @@ HTMLAttributes.unselectable
 optional value: string;
 ```
 
-Defined in: [src/components/TextField.ts:23](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/TextField.ts#L23)
+Defined in: [src/components/TextField.ts:23](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/TextField.ts#L23)
 
 ***
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/ToggleFieldProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/ToggleFieldProps.md
@@ -4,7 +4,7 @@
 
 # Interface: ToggleFieldProps
 
-Defined in: [src/components/ToggleField.ts:6](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ToggleField.ts#L6)
+Defined in: [src/components/ToggleField.ts:6](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ToggleField.ts#L6)
 
 ## Extends
 
@@ -18,7 +18,7 @@ Defined in: [src/components/ToggleField.ts:6](https://github.com/shdwmtr/pluguti
 optional bottomSeparator: "standard" | "thick" | "none";
 ```
 
-Defined in: [src/components/Item.ts:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L9)
+Defined in: [src/components/Item.ts:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L9)
 
 #### Inherited from
 
@@ -34,7 +34,7 @@ ItemProps.bottomSeparator
 checked: boolean;
 ```
 
-Defined in: [src/components/ToggleField.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ToggleField.ts#L8)
+Defined in: [src/components/ToggleField.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ToggleField.ts#L8)
 
 ***
 
@@ -44,7 +44,7 @@ Defined in: [src/components/ToggleField.ts:8](https://github.com/shdwmtr/pluguti
 optional children: ReactNode;
 ```
 
-Defined in: [src/components/Item.ts:6](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L6)
+Defined in: [src/components/Item.ts:6](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L6)
 
 #### Inherited from
 
@@ -60,7 +60,7 @@ ItemProps.children
 optional description: ReactNode;
 ```
 
-Defined in: [src/components/Item.ts:5](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L5)
+Defined in: [src/components/Item.ts:5](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L5)
 
 #### Inherited from
 
@@ -76,7 +76,7 @@ ItemProps.description
 optional disabled: boolean;
 ```
 
-Defined in: [src/components/ToggleField.ts:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ToggleField.ts#L9)
+Defined in: [src/components/ToggleField.ts:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ToggleField.ts#L9)
 
 ***
 
@@ -86,7 +86,7 @@ Defined in: [src/components/ToggleField.ts:9](https://github.com/shdwmtr/pluguti
 optional highlightOnFocus: boolean;
 ```
 
-Defined in: [src/components/ToggleField.ts:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ToggleField.ts#L7)
+Defined in: [src/components/ToggleField.ts:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ToggleField.ts#L7)
 
 #### Overrides
 
@@ -102,7 +102,7 @@ ItemProps.highlightOnFocus
 optional icon: ReactNode;
 ```
 
-Defined in: [src/components/Item.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L8)
+Defined in: [src/components/Item.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L8)
 
 #### Inherited from
 
@@ -118,7 +118,7 @@ ItemProps.icon
 optional indentLevel: number;
 ```
 
-Defined in: [src/components/Item.ts:10](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L10)
+Defined in: [src/components/Item.ts:10](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L10)
 
 #### Inherited from
 
@@ -134,7 +134,7 @@ ItemProps.indentLevel
 optional label: ReactNode;
 ```
 
-Defined in: [src/components/Item.ts:4](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L4)
+Defined in: [src/components/Item.ts:4](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L4)
 
 #### Inherited from
 
@@ -150,7 +150,7 @@ ItemProps.label
 optional layout: "below" | "inline";
 ```
 
-Defined in: [src/components/Item.ts:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L7)
+Defined in: [src/components/Item.ts:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L7)
 
 #### Inherited from
 
@@ -166,7 +166,7 @@ ItemProps.layout
 optional tooltip: string;
 ```
 
-Defined in: [src/components/Item.ts:11](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Item.ts#L11)
+Defined in: [src/components/Item.ts:11](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Item.ts#L11)
 
 #### Inherited from
 
@@ -182,7 +182,7 @@ ItemProps.tooltip
 optional onChange(checked: boolean): void
 ```
 
-Defined in: [src/components/ToggleField.ts:10](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/ToggleField.ts#L10)
+Defined in: [src/components/ToggleField.ts:10](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/ToggleField.ts#L10)
 
 #### Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/ToggleProps.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/ToggleProps.md
@@ -4,7 +4,7 @@
 
 # Interface: ToggleProps
 
-Defined in: [src/components/Toggle.ts:5](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Toggle.ts#L5)
+Defined in: [src/components/Toggle.ts:5](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Toggle.ts#L5)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/components/Toggle.ts:5](https://github.com/shdwmtr/plugutil/blo
 optional disabled: boolean;
 ```
 
-Defined in: [src/components/Toggle.ts:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Toggle.ts#L7)
+Defined in: [src/components/Toggle.ts:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Toggle.ts#L7)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/components/Toggle.ts:7](https://github.com/shdwmtr/plugutil/blo
 optional navRef: any;
 ```
 
-Defined in: [src/components/Toggle.ts:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Toggle.ts#L9)
+Defined in: [src/components/Toggle.ts:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Toggle.ts#L9)
 
 ***
 
@@ -34,7 +34,7 @@ Defined in: [src/components/Toggle.ts:9](https://github.com/shdwmtr/plugutil/blo
 value: boolean;
 ```
 
-Defined in: [src/components/Toggle.ts:6](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Toggle.ts#L6)
+Defined in: [src/components/Toggle.ts:6](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Toggle.ts#L6)
 
 ## Methods
 
@@ -44,7 +44,7 @@ Defined in: [src/components/Toggle.ts:6](https://github.com/shdwmtr/plugutil/blo
 optional onChange(checked: boolean): void
 ```
 
-Defined in: [src/components/Toggle.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Toggle.ts#L8)
+Defined in: [src/components/Toggle.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Toggle.ts#L8)
 
 #### Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/Window.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/Window.md
@@ -4,7 +4,7 @@
 
 # Interface: Window
 
-Defined in: [src/globals/SteamClient.ts:122](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L122)
+Defined in: [src/globals/SteamClient.ts:122](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L122)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/globals/SteamClient.ts:122](https://github.com/shdwmtr/plugutil
 BringToFront: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:135](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L135)
+Defined in: [src/globals/SteamClient.ts:135](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L135)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/globals/SteamClient.ts:135](https://github.com/shdwmtr/plugutil
 FlashWindow: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:138](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L138)
+Defined in: [src/globals/SteamClient.ts:138](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L138)
 
 ***
 
@@ -34,7 +34,7 @@ Defined in: [src/globals/SteamClient.ts:138](https://github.com/shdwmtr/plugutil
 GamescopeBlur: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:134](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L134)
+Defined in: [src/globals/SteamClient.ts:134](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L134)
 
 ***
 
@@ -44,7 +44,7 @@ Defined in: [src/globals/SteamClient.ts:134](https://github.com/shdwmtr/plugutil
 GetBrowserID: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:148](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L148)
+Defined in: [src/globals/SteamClient.ts:148](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L148)
 
 ***
 
@@ -54,7 +54,7 @@ Defined in: [src/globals/SteamClient.ts:148](https://github.com/shdwmtr/plugutil
 GetMousePositionDetails: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:146](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L146)
+Defined in: [src/globals/SteamClient.ts:146](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L146)
 
 ***
 
@@ -64,7 +64,7 @@ Defined in: [src/globals/SteamClient.ts:146](https://github.com/shdwmtr/plugutil
 GetWindowDimensions: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:143](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L143)
+Defined in: [src/globals/SteamClient.ts:143](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L143)
 
 ***
 
@@ -74,7 +74,7 @@ Defined in: [src/globals/SteamClient.ts:143](https://github.com/shdwmtr/plugutil
 GetWindowRestoreDetails: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:144](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L144)
+Defined in: [src/globals/SteamClient.ts:144](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L144)
 
 ***
 
@@ -84,7 +84,7 @@ Defined in: [src/globals/SteamClient.ts:144](https://github.com/shdwmtr/plugutil
 HideWindow: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:141](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L141)
+Defined in: [src/globals/SteamClient.ts:141](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L141)
 
 ***
 
@@ -94,7 +94,7 @@ Defined in: [src/globals/SteamClient.ts:141](https://github.com/shdwmtr/plugutil
 IsWindowMinimized: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:147](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L147)
+Defined in: [src/globals/SteamClient.ts:147](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L147)
 
 ***
 
@@ -104,7 +104,7 @@ Defined in: [src/globals/SteamClient.ts:147](https://github.com/shdwmtr/plugutil
 Minimize: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:126](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L126)
+Defined in: [src/globals/SteamClient.ts:126](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L126)
 
 ***
 
@@ -114,7 +114,7 @@ Defined in: [src/globals/SteamClient.ts:126](https://github.com/shdwmtr/plugutil
 MoveTo: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:129](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L129)
+Defined in: [src/globals/SteamClient.ts:129](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L129)
 
 ***
 
@@ -124,7 +124,7 @@ Defined in: [src/globals/SteamClient.ts:129](https://github.com/shdwmtr/plugutil
 PositionWindowRelative: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:145](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L145)
+Defined in: [src/globals/SteamClient.ts:145](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L145)
 
 ***
 
@@ -134,7 +134,7 @@ Defined in: [src/globals/SteamClient.ts:145](https://github.com/shdwmtr/plugutil
 ProcessShuttingDown: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:127](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L127)
+Defined in: [src/globals/SteamClient.ts:127](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L127)
 
 ***
 
@@ -144,7 +144,7 @@ Defined in: [src/globals/SteamClient.ts:127](https://github.com/shdwmtr/plugutil
 RegisterForExternalDisplayChanged: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:123](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L123)
+Defined in: [src/globals/SteamClient.ts:123](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L123)
 
 ***
 
@@ -154,7 +154,7 @@ Defined in: [src/globals/SteamClient.ts:123](https://github.com/shdwmtr/plugutil
 ResizeTo: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:130](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L130)
+Defined in: [src/globals/SteamClient.ts:130](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L130)
 
 ***
 
@@ -164,7 +164,7 @@ Defined in: [src/globals/SteamClient.ts:130](https://github.com/shdwmtr/plugutil
 SetAutoDisplayScale: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:125](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L125)
+Defined in: [src/globals/SteamClient.ts:125](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L125)
 
 ***
 
@@ -174,7 +174,7 @@ Defined in: [src/globals/SteamClient.ts:125](https://github.com/shdwmtr/plugutil
 SetComposition: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:133](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L133)
+Defined in: [src/globals/SteamClient.ts:133](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L133)
 
 ***
 
@@ -184,7 +184,7 @@ Defined in: [src/globals/SteamClient.ts:133](https://github.com/shdwmtr/plugutil
 SetForegroundWindow: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:136](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L136)
+Defined in: [src/globals/SteamClient.ts:136](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L136)
 
 ***
 
@@ -194,7 +194,7 @@ Defined in: [src/globals/SteamClient.ts:136](https://github.com/shdwmtr/plugutil
 SetKeyFocus: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:137](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L137)
+Defined in: [src/globals/SteamClient.ts:137](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L137)
 
 ***
 
@@ -204,7 +204,7 @@ Defined in: [src/globals/SteamClient.ts:137](https://github.com/shdwmtr/plugutil
 SetManualDisplayScaleFactor: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:124](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L124)
+Defined in: [src/globals/SteamClient.ts:124](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L124)
 
 ***
 
@@ -214,7 +214,7 @@ Defined in: [src/globals/SteamClient.ts:124](https://github.com/shdwmtr/plugutil
 SetMinSize: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:131](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L131)
+Defined in: [src/globals/SteamClient.ts:131](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L131)
 
 ***
 
@@ -224,7 +224,7 @@ Defined in: [src/globals/SteamClient.ts:131](https://github.com/shdwmtr/plugutil
 SetResizeGrip: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:132](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L132)
+Defined in: [src/globals/SteamClient.ts:132](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L132)
 
 ***
 
@@ -234,7 +234,7 @@ Defined in: [src/globals/SteamClient.ts:132](https://github.com/shdwmtr/plugutil
 SetWindowIcon: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:142](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L142)
+Defined in: [src/globals/SteamClient.ts:142](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L142)
 
 ***
 
@@ -244,7 +244,7 @@ Defined in: [src/globals/SteamClient.ts:142](https://github.com/shdwmtr/plugutil
 ShowWindow: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:140](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L140)
+Defined in: [src/globals/SteamClient.ts:140](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L140)
 
 ***
 
@@ -254,7 +254,7 @@ Defined in: [src/globals/SteamClient.ts:140](https://github.com/shdwmtr/plugutil
 StopFlashWindow: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:139](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L139)
+Defined in: [src/globals/SteamClient.ts:139](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L139)
 
 ***
 
@@ -264,4 +264,4 @@ Defined in: [src/globals/SteamClient.ts:139](https://github.com/shdwmtr/plugutil
 ToggleMaximize: any;
 ```
 
-Defined in: [src/globals/SteamClient.ts:128](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L128)
+Defined in: [src/globals/SteamClient.ts:128](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L128)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/WindowRouter.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/WindowRouter.md
@@ -4,7 +4,7 @@
 
 # Interface: WindowRouter
 
-Defined in: [src/modules/Router.ts:74](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L74)
+Defined in: [src/modules/Router.ts:74](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L74)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/modules/Router.ts:74](https://github.com/shdwmtr/plugutil/blob/
 BrowserWindow: Window;
 ```
 
-Defined in: [src/modules/Router.ts:75](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L75)
+Defined in: [src/modules/Router.ts:75](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L75)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/modules/Router.ts:75](https://github.com/shdwmtr/plugutil/blob/
 MenuStore: MenuStore;
 ```
 
-Defined in: [src/modules/Router.ts:76](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L76)
+Defined in: [src/modules/Router.ts:76](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L76)
 
 ## Methods
 
@@ -34,7 +34,7 @@ Defined in: [src/modules/Router.ts:76](https://github.com/shdwmtr/plugutil/blob/
 Navigate(path: string): void
 ```
 
-Defined in: [src/modules/Router.ts:77](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L77)
+Defined in: [src/modules/Router.ts:77](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L77)
 
 #### Parameters
 
@@ -54,7 +54,7 @@ Defined in: [src/modules/Router.ts:77](https://github.com/shdwmtr/plugutil/blob/
 NavigateBack(): void
 ```
 
-Defined in: [src/modules/Router.ts:80](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L80)
+Defined in: [src/modules/Router.ts:80](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L80)
 
 #### Returns
 
@@ -68,7 +68,7 @@ Defined in: [src/modules/Router.ts:80](https://github.com/shdwmtr/plugutil/blob/
 NavigateToChat(): void
 ```
 
-Defined in: [src/modules/Router.ts:78](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L78)
+Defined in: [src/modules/Router.ts:78](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L78)
 
 #### Returns
 
@@ -82,7 +82,7 @@ Defined in: [src/modules/Router.ts:78](https://github.com/shdwmtr/plugutil/blob/
 NavigateToSteamWeb(url: string): void
 ```
 
-Defined in: [src/modules/Router.ts:79](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L79)
+Defined in: [src/modules/Router.ts:79](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L79)
 
 #### Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/interfaces/WindowStore.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/WindowStore.md
@@ -4,7 +4,7 @@
 
 # Interface: WindowStore
 
-Defined in: [src/modules/Router.ts:83](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L83)
+Defined in: [src/modules/Router.ts:83](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L83)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/modules/Router.ts:83](https://github.com/shdwmtr/plugutil/blob/
 optional GamepadUIMainWindowInstance: WindowRouter;
 ```
 
-Defined in: [src/modules/Router.ts:84](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L84)
+Defined in: [src/modules/Router.ts:84](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L84)
 
 ***
 
@@ -24,7 +24,7 @@ Defined in: [src/modules/Router.ts:84](https://github.com/shdwmtr/plugutil/blob/
 OverlayWindows: WindowRouter[];
 ```
 
-Defined in: [src/modules/Router.ts:86](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L86)
+Defined in: [src/modules/Router.ts:86](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L86)
 
 ***
 
@@ -34,4 +34,4 @@ Defined in: [src/modules/Router.ts:86](https://github.com/shdwmtr/plugutil/blob/
 SteamUIWindows: WindowRouter[];
 ```
 
-Defined in: [src/modules/Router.ts:85](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L85)
+Defined in: [src/modules/Router.ts:85](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L85)

--- a/docs/ui/developers/plugins/typescript/client/interfaces/findInTreeOpts.md
+++ b/docs/ui/developers/plugins/typescript/client/interfaces/findInTreeOpts.md
@@ -4,7 +4,7 @@
 
 # Interface: findInTreeOpts
 
-Defined in: [src/utils/react.ts:109](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/react.ts#L109)
+Defined in: [src/utils/react.ts:109](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/react.ts#L109)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/utils/react.ts:109](https://github.com/shdwmtr/plugutil/blob/b5
 optional ignore: string[];
 ```
 
-Defined in: [src/utils/react.ts:111](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/react.ts#L111)
+Defined in: [src/utils/react.ts:111](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/react.ts#L111)
 
 ***
 
@@ -24,4 +24,4 @@ Defined in: [src/utils/react.ts:111](https://github.com/shdwmtr/plugutil/blob/b5
 optional walkable: string[];
 ```
 
-Defined in: [src/utils/react.ts:110](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/react.ts#L110)
+Defined in: [src/utils/react.ts:110](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/react.ts#L110)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/AchievementListClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/AchievementListClasses.md
@@ -55,4 +55,4 @@ type AchievementListClasses = Record<
 | "nGlobalAchievementHeight", string>;
 ```
 
-Defined in: [src/utils/static-classes.ts:652](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L652)
+Defined in: [src/utils/static-classes.ts:652](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L652)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/AchievementPageClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/AchievementPageClasses.md
@@ -85,4 +85,4 @@ type AchievementPageClasses = Record<
 | "nGlobalAchievementHeight", string>;
 ```
 
-Defined in: [src/utils/static-classes.ts:703](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L703)
+Defined in: [src/utils/static-classes.ts:703](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L703)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/ActionDescriptionMap.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/ActionDescriptionMap.md
@@ -12,4 +12,4 @@ component: UI Components
 type ActionDescriptionMap = { [key in GamepadButton]?: ReactNode };
 ```
 
-Defined in: [src/components/FooterLegend.ts:47](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L47)
+Defined in: [src/components/FooterLegend.ts:47](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L47)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/AppAchievements.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/AppAchievements.md
@@ -14,7 +14,7 @@ type AppAchievements = {
 };
 ```
 
-Defined in: [src/globals/SteamClient.ts:211](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L211)
+Defined in: [src/globals/SteamClient.ts:211](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L211)
 
 ## Type declaration
 

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/AppActionButtonClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/AppActionButtonClasses.md
@@ -55,4 +55,4 @@ type AppActionButtonClasses = Record<
 | "rotate", string>;
 ```
 
-Defined in: [src/utils/static-classes.ts:902](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L902)
+Defined in: [src/utils/static-classes.ts:902](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L902)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/AppDetailsClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/AppDetailsClasses.md
@@ -44,4 +44,4 @@ type AppDetailsClasses = Record<
 | "hoverAnimation", string>;
 ```
 
-Defined in: [src/utils/static-classes.ts:475](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L475)
+Defined in: [src/utils/static-classes.ts:475](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L475)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/AppDetailsHeaderClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/AppDetailsHeaderClasses.md
@@ -60,4 +60,4 @@ type AppDetailsHeaderClasses = Record<
 | "duration-app-launch", string>;
 ```
 
-Defined in: [src/utils/static-classes.ts:419](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L419)
+Defined in: [src/utils/static-classes.ts:419](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L419)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/AppLanguages.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/AppLanguages.md
@@ -11,7 +11,7 @@ type AppLanguages = {
 };
 ```
 
-Defined in: [src/globals/SteamClient.ts:219](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L219)
+Defined in: [src/globals/SteamClient.ts:219](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L219)
 
 ## Type declaration
 

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/AppOverview.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/AppOverview.md
@@ -13,7 +13,7 @@ type AppOverview = {
 };
 ```
 
-Defined in: [src/modules/Router.ts:61](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L61)
+Defined in: [src/modules/Router.ts:61](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L61)
 
 ## Type declaration
 

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/BasicAppDetailsSectionStylerClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/BasicAppDetailsSectionStylerClasses.md
@@ -30,4 +30,4 @@ type BasicAppDetailsSectionStylerClasses = Record<
 | "headerPadding", string>;
 ```
 
-Defined in: [src/utils/static-classes.ts:828](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L828)
+Defined in: [src/utils/static-classes.ts:828](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L828)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/DropdownOption.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/DropdownOption.md
@@ -10,4 +10,4 @@ type DropdownOption =
   | MultiDropdownOption;
 ```
 
-Defined in: [src/components/Dropdown.ts:21](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/Dropdown.ts#L21)
+Defined in: [src/components/Dropdown.ts:21](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/Dropdown.ts#L21)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/FocusRingClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/FocusRingClasses.md
@@ -16,4 +16,4 @@ type FocusRingClasses = Record<
 | "growOutline", string>;
 ```
 
-Defined in: [src/utils/static-classes.ts:1005](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1005)
+Defined in: [src/utils/static-classes.ts:1005](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1005)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/FooterClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/FooterClasses.md
@@ -28,4 +28,4 @@ type FooterClasses = Record<
 | "hoverAnimation", string>;
 ```
 
-Defined in: [src/utils/static-classes.ts:878](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L878)
+Defined in: [src/utils/static-classes.ts:878](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L878)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/GamepadContextMenuClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/GamepadContextMenuClasses.md
@@ -43,4 +43,4 @@ type GamepadContextMenuClasses = Record<
 | "slideInAnimation", string>;
 ```
 
-Defined in: [src/utils/static-classes.ts:613](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L613)
+Defined in: [src/utils/static-classes.ts:613](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L613)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/GamepadDialogClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/GamepadDialogClasses.md
@@ -82,4 +82,4 @@ type GamepadDialogClasses = Record<
 | "slideInAnimation", string>;
 ```
 
-Defined in: [src/utils/static-classes.ts:81](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L81)
+Defined in: [src/utils/static-classes.ts:81](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L81)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/GamepadEvent.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/GamepadEvent.md
@@ -12,4 +12,4 @@ component: UI Components
 type GamepadEvent = CustomEvent<GamepadEventDetail>;
 ```
 
-Defined in: [src/components/FooterLegend.ts:51](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/components/FooterLegend.ts#L51)
+Defined in: [src/components/FooterLegend.ts:51](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/components/FooterLegend.ts#L51)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/GamepadLibraryClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/GamepadLibraryClasses.md
@@ -39,4 +39,4 @@ type GamepadLibraryClasses = Record<
 | "hoverAnimation", string>;
 ```
 
-Defined in: [src/utils/static-classes.ts:970](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L970)
+Defined in: [src/utils/static-classes.ts:970](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L970)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/GamepadSliderClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/GamepadSliderClasses.md
@@ -63,4 +63,4 @@ type GamepadSliderClasses = Record<
 | "error-shake-duration", string>;
 ```
 
-Defined in: [src/utils/static-classes.ts:360](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L360)
+Defined in: [src/utils/static-classes.ts:360](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L360)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/GamepadTabbedPageClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/GamepadTabbedPageClasses.md
@@ -60,4 +60,4 @@ type GamepadTabbedPageClasses = Record<
 | "headerHeight", string>;
 ```
 
-Defined in: [src/utils/static-classes.ts:557](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L557)
+Defined in: [src/utils/static-classes.ts:557](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L557)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/GamepadUIClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/GamepadUIClasses.md
@@ -46,4 +46,4 @@ type GamepadUIClasses = Record<
 | "vrgamepadui-floating-side-panel-width", string>;
 ```
 
-Defined in: [src/utils/static-classes.ts:515](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L515)
+Defined in: [src/utils/static-classes.ts:515](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L515)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/GenericPatchHandler.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/GenericPatchHandler.md
@@ -8,7 +8,7 @@
 type GenericPatchHandler = (args: any[], ret?: any) => any;
 ```
 
-Defined in: [src/utils/patcher.ts:9](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/patcher.ts#L9)
+Defined in: [src/utils/patcher.ts:9](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/patcher.ts#L9)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/IPC_types.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/IPC_types.md
@@ -8,6 +8,6 @@
 type IPC_types = string | number | boolean;
 ```
 
-Defined in: [src/api/index.ts:2](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/api/index.ts#L2)
+Defined in: [src/api/index.ts:2](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/api/index.ts#L2)
 
 Returnable IPC types

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/LibraryAssetImageClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/LibraryAssetImageClasses.md
@@ -21,4 +21,4 @@ type LibraryAssetImageClasses = Record<
 | "duration-app-launch", string>;
 ```
 
-Defined in: [src/utils/static-classes.ts:953](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L953)
+Defined in: [src/utils/static-classes.ts:953](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L953)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/LogoPinPositions.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/LogoPinPositions.md
@@ -13,4 +13,4 @@ type LogoPinPositions =
   | "BottomCenter";
 ```
 
-Defined in: [src/globals/SteamClient.ts:224](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/globals/SteamClient.ts#L224)
+Defined in: [src/globals/SteamClient.ts:224](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/globals/SteamClient.ts#L224)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/MainBrowserClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/MainBrowserClasses.md
@@ -27,4 +27,4 @@ type MainBrowserClasses = Record<
 | "showSupportLevel", string>;
 ```
 
-Defined in: [src/utils/static-classes.ts:1043](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1043)
+Defined in: [src/utils/static-classes.ts:1043](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1043)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/MainMenuAppRunningClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/MainMenuAppRunningClasses.md
@@ -48,4 +48,4 @@ type MainMenuAppRunningClasses = Record<
 | "hoverAnimation", string>;
 ```
 
-Defined in: [src/utils/static-classes.ts:784](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L784)
+Defined in: [src/utils/static-classes.ts:784](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L784)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/Millennium.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/Millennium.md
@@ -17,7 +17,7 @@ type Millennium = {
 };
 ```
 
-Defined in: [src/api/index.ts:5](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/api/index.ts#L5)
+Defined in: [src/api/index.ts:5](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/api/index.ts#L5)
 
 ## Type declaration
 

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/PlaySectionClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/PlaySectionClasses.md
@@ -124,4 +124,4 @@ type PlaySectionClasses = Record<
 | "hoverAnimation", string>;
 ```
 
-Defined in: [src/utils/static-classes.ts:240](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L240)
+Defined in: [src/utils/static-classes.ts:240](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L240)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/QuickAccessControlsClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/QuickAccessControlsClasses.md
@@ -39,4 +39,4 @@ type QuickAccessControlsClasses = Record<
 | "hoverAnimation", string>;
 ```
 
-Defined in: [src/utils/static-classes.ts:159](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L159)
+Defined in: [src/utils/static-classes.ts:159](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L159)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/QuickAccessMenuClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/QuickAccessMenuClasses.md
@@ -80,4 +80,4 @@ type QuickAccessMenuClasses = Record<
 | "vrgamepadui-floating-side-panel-width", string>;
 ```
 
-Defined in: [src/utils/static-classes.ts:3](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L3)
+Defined in: [src/utils/static-classes.ts:3](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L3)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/ReorderableEntry.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/ReorderableEntry.md
@@ -12,7 +12,7 @@ type ReorderableEntry<T> = {
 };
 ```
 
-Defined in: [src/custom-components/ReorderableList.tsx:11](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/custom-components/ReorderableList.tsx#L11)
+Defined in: [src/custom-components/ReorderableList.tsx:11](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/custom-components/ReorderableList.tsx#L11)
 
 A ReorderableList entry of type <T>.
 

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/ReorderableListEntryProps.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/ReorderableListEntryProps.md
@@ -16,7 +16,7 @@ type ReorderableListEntryProps<T> = {
 };
 ```
 
-Defined in: [src/custom-components/ReorderableList.tsx:105](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/custom-components/ReorderableList.tsx#L105)
+Defined in: [src/custom-components/ReorderableList.tsx:105](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/custom-components/ReorderableList.tsx#L105)
 
 Properties for a ReorderableItem component of type <T>
 

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/ReorderableListProps.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/ReorderableListProps.md
@@ -16,7 +16,7 @@ type ReorderableListProps<T> = {
 };
 ```
 
-Defined in: [src/custom-components/ReorderableList.tsx:22](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/custom-components/ReorderableList.tsx#L22)
+Defined in: [src/custom-components/ReorderableList.tsx:22](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/custom-components/ReorderableList.tsx#L22)
 
 Properties for a ReorderableList component of type <T>.
 

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/ScrollPanelClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/ScrollPanelClasses.md
@@ -8,4 +8,4 @@
 type ScrollPanelClasses = Record<"ScrollBoth" | "ScrollPanel" | "ScrollX" | "ScrollY", string>;
 ```
 
-Defined in: [src/utils/static-classes.ts:79](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L79)
+Defined in: [src/utils/static-classes.ts:79](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L79)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/SearchBarClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/SearchBarClasses.md
@@ -30,4 +30,4 @@ type SearchBarClasses = Record<
 | "duration-app-launch", string>;
 ```
 
-Defined in: [src/utils/static-classes.ts:1017](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1017)
+Defined in: [src/utils/static-classes.ts:1017](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1017)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/SteamSpinnerClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/SteamSpinnerClasses.md
@@ -28,4 +28,4 @@ type SteamSpinnerClasses = Record<
 | "hoverAnimation", string>;
 ```
 
-Defined in: [src/utils/static-classes.ts:854](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L854)
+Defined in: [src/utils/static-classes.ts:854](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L854)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/UpdaterFieldClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/UpdaterFieldClasses.md
@@ -50,4 +50,4 @@ type UpdaterFieldClasses = Record<
 | "hoverAnimation", string>;
 ```
 
-Defined in: [src/utils/static-classes.ts:194](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L194)
+Defined in: [src/utils/static-classes.ts:194](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L194)

--- a/docs/ui/developers/plugins/typescript/client/type-aliases/findInTreeFilter.md
+++ b/docs/ui/developers/plugins/typescript/client/type-aliases/findInTreeFilter.md
@@ -8,7 +8,7 @@
 type findInTreeFilter = (element: any) => boolean;
 ```
 
-Defined in: [src/utils/react.ts:114](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/react.ts#L114)
+Defined in: [src/utils/react.ts:114](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/react.ts#L114)
 
 ## Parameters
 

--- a/docs/ui/developers/plugins/typescript/client/variables/Classes.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/Classes.md
@@ -8,4 +8,4 @@
 const Classes: any;
 ```
 
-Defined in: [src/class-mapper.ts:36](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/class-mapper.ts#L36)
+Defined in: [src/class-mapper.ts:36](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/class-mapper.ts#L36)

--- a/docs/ui/developers/plugins/typescript/client/variables/Millennium.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/Millennium.md
@@ -8,4 +8,4 @@
 Millennium: Millennium;
 ```
 
-Defined in: [src/api/index.ts:5](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/api/index.ts#L5)
+Defined in: [src/api/index.ts:5](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/api/index.ts#L5)

--- a/docs/ui/developers/plugins/typescript/client/variables/Navigation.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/Navigation.md
@@ -8,4 +8,4 @@
 Navigation: Navigation;
 ```
 
-Defined in: [src/modules/Router.ts:106](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L106)
+Defined in: [src/modules/Router.ts:106](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L106)

--- a/docs/ui/developers/plugins/typescript/client/variables/Router.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/Router.md
@@ -8,4 +8,4 @@
 Router: Router;
 ```
 
-Defined in: [src/modules/Router.ts:89](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/modules/Router.ts#L89)
+Defined in: [src/modules/Router.ts:89](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L89)

--- a/docs/ui/developers/plugins/typescript/client/variables/achievementClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/achievementClasses.md
@@ -8,7 +8,7 @@
 const achievementClasses: AchievementListClasses = achievementListClasses;
 ```
 
-Defined in: [src/utils/static-classes.ts:1104](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1104)
+Defined in: [src/utils/static-classes.ts:1104](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1104)
 
 ## Deprecated
 

--- a/docs/ui/developers/plugins/typescript/client/variables/achievementListClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/achievementListClasses.md
@@ -8,4 +8,4 @@
 const achievementListClasses: AchievementListClasses;
 ```
 
-Defined in: [src/utils/static-classes.ts:1078](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1078)
+Defined in: [src/utils/static-classes.ts:1078](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1078)

--- a/docs/ui/developers/plugins/typescript/client/variables/achievementPageClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/achievementPageClasses.md
@@ -8,4 +8,4 @@
 const achievementPageClasses: AchievementPageClasses;
 ```
 
-Defined in: [src/utils/static-classes.ts:1079](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1079)
+Defined in: [src/utils/static-classes.ts:1079](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1079)

--- a/docs/ui/developers/plugins/typescript/client/variables/appActionButtonClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/appActionButtonClasses.md
@@ -8,4 +8,4 @@
 const appActionButtonClasses: AppActionButtonClasses;
 ```
 
-Defined in: [src/utils/static-classes.ts:1084](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1084)
+Defined in: [src/utils/static-classes.ts:1084](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1084)

--- a/docs/ui/developers/plugins/typescript/client/variables/appDetailsClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/appDetailsClasses.md
@@ -8,4 +8,4 @@
 const appDetailsClasses: AppDetailsClasses;
 ```
 
-Defined in: [src/utils/static-classes.ts:1074](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1074)
+Defined in: [src/utils/static-classes.ts:1074](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1074)

--- a/docs/ui/developers/plugins/typescript/client/variables/appDetailsHeaderClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/appDetailsHeaderClasses.md
@@ -8,4 +8,4 @@
 const appDetailsHeaderClasses: AppDetailsHeaderClasses;
 ```
 
-Defined in: [src/utils/static-classes.ts:1073](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1073)
+Defined in: [src/utils/static-classes.ts:1073](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1073)

--- a/docs/ui/developers/plugins/typescript/client/variables/basicAppDetailsSectionStylerClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/basicAppDetailsSectionStylerClasses.md
@@ -8,4 +8,4 @@
 const basicAppDetailsSectionStylerClasses: BasicAppDetailsSectionStylerClasses;
 ```
 
-Defined in: [src/utils/static-classes.ts:1081](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1081)
+Defined in: [src/utils/static-classes.ts:1081](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1081)

--- a/docs/ui/developers/plugins/typescript/client/variables/callOriginal.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/callOriginal.md
@@ -8,4 +8,4 @@
 callOriginal: symbol;
 ```
 
-Defined in: [src/utils/patcher.ts:3](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/patcher.ts#L3)
+Defined in: [src/utils/patcher.ts:3](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/patcher.ts#L3)

--- a/docs/ui/developers/plugins/typescript/client/variables/classMap.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/classMap.md
@@ -8,4 +8,4 @@
 const classMap: ClassModule;
 ```
 
-Defined in: [src/class-mapper.ts:20](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/class-mapper.ts#L20)
+Defined in: [src/class-mapper.ts:20](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/class-mapper.ts#L20)

--- a/docs/ui/developers/plugins/typescript/client/variables/classMapList.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/classMapList.md
@@ -8,4 +8,4 @@
 const classMapList: ClassModule[];
 ```
 
-Defined in: [src/class-mapper.ts:7](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/class-mapper.ts#L7)
+Defined in: [src/class-mapper.ts:7](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/class-mapper.ts#L7)

--- a/docs/ui/developers/plugins/typescript/client/variables/focusRingClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/focusRingClasses.md
@@ -8,4 +8,4 @@
 const focusRingClasses: FocusRingClasses;
 ```
 
-Defined in: [src/utils/static-classes.ts:1087](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1087)
+Defined in: [src/utils/static-classes.ts:1087](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1087)

--- a/docs/ui/developers/plugins/typescript/client/variables/footerClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/footerClasses.md
@@ -8,4 +8,4 @@
 const footerClasses: FooterClasses;
 ```
 
-Defined in: [src/utils/static-classes.ts:1083](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1083)
+Defined in: [src/utils/static-classes.ts:1083](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1083)

--- a/docs/ui/developers/plugins/typescript/client/variables/gamepadContextMenuClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/gamepadContextMenuClasses.md
@@ -8,4 +8,4 @@
 const gamepadContextMenuClasses: GamepadContextMenuClasses;
 ```
 
-Defined in: [src/utils/static-classes.ts:1077](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1077)
+Defined in: [src/utils/static-classes.ts:1077](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1077)

--- a/docs/ui/developers/plugins/typescript/client/variables/gamepadDialogClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/gamepadDialogClasses.md
@@ -8,4 +8,4 @@
 const gamepadDialogClasses: GamepadDialogClasses;
 ```
 
-Defined in: [src/utils/static-classes.ts:1068](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1068)
+Defined in: [src/utils/static-classes.ts:1068](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1068)

--- a/docs/ui/developers/plugins/typescript/client/variables/gamepadLibraryClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/gamepadLibraryClasses.md
@@ -8,4 +8,4 @@
 const gamepadLibraryClasses: GamepadLibraryClasses;
 ```
 
-Defined in: [src/utils/static-classes.ts:1086](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1086)
+Defined in: [src/utils/static-classes.ts:1086](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1086)

--- a/docs/ui/developers/plugins/typescript/client/variables/gamepadSliderClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/gamepadSliderClasses.md
@@ -8,4 +8,4 @@
 const gamepadSliderClasses: GamepadSliderClasses;
 ```
 
-Defined in: [src/utils/static-classes.ts:1072](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1072)
+Defined in: [src/utils/static-classes.ts:1072](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1072)

--- a/docs/ui/developers/plugins/typescript/client/variables/gamepadTabbedPageClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/gamepadTabbedPageClasses.md
@@ -8,4 +8,4 @@
 const gamepadTabbedPageClasses: GamepadTabbedPageClasses;
 ```
 
-Defined in: [src/utils/static-classes.ts:1076](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1076)
+Defined in: [src/utils/static-classes.ts:1076](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1076)

--- a/docs/ui/developers/plugins/typescript/client/variables/gamepadUIClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/gamepadUIClasses.md
@@ -8,4 +8,4 @@
 const gamepadUIClasses: GamepadUIClasses;
 ```
 
-Defined in: [src/utils/static-classes.ts:1075](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1075)
+Defined in: [src/utils/static-classes.ts:1075](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1075)

--- a/docs/ui/developers/plugins/typescript/client/variables/libraryAssetImageClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/libraryAssetImageClasses.md
@@ -8,4 +8,4 @@
 const libraryAssetImageClasses: LibraryAssetImageClasses;
 ```
 
-Defined in: [src/utils/static-classes.ts:1085](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1085)
+Defined in: [src/utils/static-classes.ts:1085](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1085)

--- a/docs/ui/developers/plugins/typescript/client/variables/mainBrowserClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/mainBrowserClasses.md
@@ -8,4 +8,4 @@
 const mainBrowserClasses: MainBrowserClasses;
 ```
 
-Defined in: [src/utils/static-classes.ts:1089](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1089)
+Defined in: [src/utils/static-classes.ts:1089](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1089)

--- a/docs/ui/developers/plugins/typescript/client/variables/mainMenuAppRunningClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/mainMenuAppRunningClasses.md
@@ -8,4 +8,4 @@
 const mainMenuAppRunningClasses: MainMenuAppRunningClasses;
 ```
 
-Defined in: [src/utils/static-classes.ts:1080](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1080)
+Defined in: [src/utils/static-classes.ts:1080](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1080)

--- a/docs/ui/developers/plugins/typescript/client/variables/playSectionClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/playSectionClasses.md
@@ -8,4 +8,4 @@
 const playSectionClasses: PlaySectionClasses;
 ```
 
-Defined in: [src/utils/static-classes.ts:1071](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1071)
+Defined in: [src/utils/static-classes.ts:1071](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1071)

--- a/docs/ui/developers/plugins/typescript/client/variables/pluginSelf.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/pluginSelf.md
@@ -12,7 +12,7 @@ component: Core
 const pluginSelf: any = m_private_context;
 ```
 
-Defined in: [src/api/index.ts:108](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/api/index.ts#L108)
+Defined in: [src/api/index.ts:108](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/api/index.ts#L108)
 
 `pluginSelf` is a sandbox for data specific to your plugin. 
 You can't access other plugins sandboxes and they can't access yours.

--- a/docs/ui/developers/plugins/typescript/client/variables/quickAccessControlsClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/quickAccessControlsClasses.md
@@ -8,4 +8,4 @@
 const quickAccessControlsClasses: QuickAccessControlsClasses;
 ```
 
-Defined in: [src/utils/static-classes.ts:1069](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1069)
+Defined in: [src/utils/static-classes.ts:1069](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1069)

--- a/docs/ui/developers/plugins/typescript/client/variables/quickAccessMenuClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/quickAccessMenuClasses.md
@@ -8,4 +8,4 @@
 const quickAccessMenuClasses: QuickAccessMenuClasses;
 ```
 
-Defined in: [src/utils/static-classes.ts:1066](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1066)
+Defined in: [src/utils/static-classes.ts:1066](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1066)

--- a/docs/ui/developers/plugins/typescript/client/variables/scrollClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/scrollClasses.md
@@ -8,7 +8,7 @@
 const scrollClasses: ScrollPanelClasses = scrollPanelClasses;
 ```
 
-Defined in: [src/utils/static-classes.ts:1099](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1099)
+Defined in: [src/utils/static-classes.ts:1099](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1099)
 
 ## Deprecated
 

--- a/docs/ui/developers/plugins/typescript/client/variables/scrollPanelClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/scrollPanelClasses.md
@@ -8,4 +8,4 @@
 const scrollPanelClasses: ScrollPanelClasses;
 ```
 
-Defined in: [src/utils/static-classes.ts:1067](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1067)
+Defined in: [src/utils/static-classes.ts:1067](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1067)

--- a/docs/ui/developers/plugins/typescript/client/variables/searchBarClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/searchBarClasses.md
@@ -8,4 +8,4 @@
 const searchBarClasses: SearchBarClasses;
 ```
 
-Defined in: [src/utils/static-classes.ts:1088](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1088)
+Defined in: [src/utils/static-classes.ts:1088](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1088)

--- a/docs/ui/developers/plugins/typescript/client/variables/staticClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/staticClasses.md
@@ -8,7 +8,7 @@
 const staticClasses: QuickAccessMenuClasses = quickAccessMenuClasses;
 ```
 
-Defined in: [src/utils/static-classes.ts:1094](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1094)
+Defined in: [src/utils/static-classes.ts:1094](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1094)
 
 ## Deprecated
 

--- a/docs/ui/developers/plugins/typescript/client/variables/steamSpinnerClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/steamSpinnerClasses.md
@@ -8,4 +8,4 @@
 const steamSpinnerClasses: SteamSpinnerClasses;
 ```
 
-Defined in: [src/utils/static-classes.ts:1082](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1082)
+Defined in: [src/utils/static-classes.ts:1082](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1082)

--- a/docs/ui/developers/plugins/typescript/client/variables/updaterFieldClasses.md
+++ b/docs/ui/developers/plugins/typescript/client/variables/updaterFieldClasses.md
@@ -8,4 +8,4 @@
 const updaterFieldClasses: UpdaterFieldClasses;
 ```
 
-Defined in: [src/utils/static-classes.ts:1070](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/client/src/utils/static-classes.ts#L1070)
+Defined in: [src/utils/static-classes.ts:1070](https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/utils/static-classes.ts#L1070)

--- a/docs/ui/developers/plugins/typescript/webkit/functions/callable.md
+++ b/docs/ui/developers/plugins/typescript/webkit/functions/callable.md
@@ -12,7 +12,7 @@ component: Core
 function callable<Args, T>(route: string): (...args: Args) => Promise<T>
 ```
 
-Defined in: [index.ts:56](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/webkit/src/index.ts#L56)
+Defined in: [index.ts:56](https://github.com/SteamClientHomebrew/SDK/blob/main/webkit/src/index.ts#L56)
 
 Make reusable IPC call declarations
 

--- a/docs/ui/developers/plugins/typescript/webkit/type-aliases/IPC_types.md
+++ b/docs/ui/developers/plugins/typescript/webkit/type-aliases/IPC_types.md
@@ -8,6 +8,6 @@
 type IPC_types = string | number | boolean | void;
 ```
 
-Defined in: [index.ts:8](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/webkit/src/index.ts#L8)
+Defined in: [index.ts:8](https://github.com/SteamClientHomebrew/SDK/blob/main/webkit/src/index.ts#L8)
 
 Returnable IPC types

--- a/docs/ui/developers/plugins/typescript/webkit/type-aliases/Millennium.md
+++ b/docs/ui/developers/plugins/typescript/webkit/type-aliases/Millennium.md
@@ -15,7 +15,7 @@ type Millennium = {
 };
 ```
 
-Defined in: [index.ts:11](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/webkit/src/index.ts#L11)
+Defined in: [index.ts:11](https://github.com/SteamClientHomebrew/SDK/blob/main/webkit/src/index.ts#L11)
 
 ## Type declaration
 

--- a/docs/ui/developers/plugins/typescript/webkit/variables/Millennium.md
+++ b/docs/ui/developers/plugins/typescript/webkit/variables/Millennium.md
@@ -8,4 +8,4 @@
 Millennium: Millennium;
 ```
 
-Defined in: [index.ts:11](https://github.com/shdwmtr/plugutil/blob/b52230e3bd417b9353d983856323dee8a90c4f70/webkit/src/index.ts#L11)
+Defined in: [index.ts:11](https://github.com/SteamClientHomebrew/SDK/blob/main/webkit/src/index.ts#L11)


### PR DESCRIPTION
Marking this pull request as a draft as its not finished. Any form of help in this is appreciated.
Almost all of the Line links (https://github.com/SteamClientHomebrew/SDK/blob/main/typescript-packages/client/src/modules/Router.ts#L22 like this one for example) are a couple of lines off or some of them no longer exist. 

---

Currently https://docs.steambrew.app gets all of the defined links from a specific commit which was made on Dec of 2024. pretty much making almost all of the lines of code outdated currently present on the website. 
This pull request makes the website grab the main branch of the source code. So that way it wont relay on a specific commit.