### PR TITLE
Support for rendering github alerts in markdown converter

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -29,6 +29,7 @@
 		"react-select": "^5.10.1",
 		"react-toastify": "^10.0.6",
 		"react-tooltip": "^5.28.0",
+		"rehype-github-alert": "^1.0.0",
 		"rehype-raw": "^7.0.0",
 		"rehype-sanitize": "^6.0.0",
 		"rehype-stringify": "^10.0.1",

--- a/www/pnpm-lock.yaml
+++ b/www/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       react-tooltip:
         specifier: ^5.28.0
         version: 5.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      rehype-github-alert:
+        specifier: ^1.0.0
+        version: 1.0.0
       rehype-raw:
         specifier: ^7.0.0
         version: 7.0.0
@@ -2755,6 +2758,9 @@ packages:
   registry-url@5.1.0:
     resolution: {integrity: sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==}
     engines: {node: '>=8'}
+
+  rehype-github-alert@1.0.0:
+    resolution: {integrity: sha512-Ijn6RGfqQTcqEvB4C7qfpk85NhVA7tncuUH8sncM45xrtuvlEt3Z9OHwoCZ8a/8wpXwfBDn9xorCVihLHg2O1w==}
 
   rehype-raw@7.0.0:
     resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
@@ -6557,6 +6563,12 @@ snapshots:
   registry-url@5.1.0:
     dependencies:
       rc: 1.2.8
+
+  rehype-github-alert@1.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-whitespace: 3.0.0
+      unist-util-visit: 5.0.0
 
   rehype-raw@7.0.0:
     dependencies:

--- a/www/src/css/index.css
+++ b/www/src/css/index.css
@@ -4301,6 +4301,10 @@ canvas {
   fill: currentColor;
 }
 
+.markdown-body .mr-2 {
+  margin-right: 0.5rem !important;
+}
+
 .markdown-body .markdown-alert {
   padding: 0.5rem 1rem;
   margin-bottom: 1rem;
@@ -4318,7 +4322,6 @@ canvas {
 
 .markdown-body .markdown-alert .markdown-alert-title {
   display: flex;
-	gap: 0.5rem;
   font-weight: 500;
   align-items: center;
   line-height: 1;

--- a/www/src/css/index.css
+++ b/www/src/css/index.css
@@ -4294,6 +4294,76 @@ canvas {
 	padding: 0 !important;
 }
 
+.markdown-body .octicon {
+  display: inline-block;
+  overflow: visible !important;
+  vertical-align: text-bottom;
+  fill: currentColor;
+}
+
+.markdown-body .markdown-alert {
+  padding: 0.5rem 1rem;
+  margin-bottom: 1rem;
+  color: inherit;
+  border-left: .25em solid #3d444d;
+}
+
+.markdown-body .markdown-alert>:first-child {
+  margin-top: 0;
+}
+
+.markdown-body .markdown-alert>:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body .markdown-alert .markdown-alert-title {
+  display: flex;
+	gap: 0.5rem;
+  font-weight: 500;
+  align-items: center;
+  line-height: 1;
+}
+
+.markdown-body .markdown-alert.markdown-alert-note {
+  border-left-color: #1f6feb;
+}
+
+.markdown-body .markdown-alert.markdown-alert-note .markdown-alert-title {
+  color: #4493f8;
+}
+
+.markdown-body .markdown-alert.markdown-alert-important {
+  border-left-color: #8957e5;
+}
+
+.markdown-body .markdown-alert.markdown-alert-important .markdown-alert-title {
+  color: #ab7df8;
+}
+
+.markdown-body .markdown-alert.markdown-alert-warning {
+  border-left-color: #9e6a03;
+}
+
+.markdown-body .markdown-alert.markdown-alert-warning .markdown-alert-title {
+  color: #d29922;
+}
+
+.markdown-body .markdown-alert.markdown-alert-tip {
+  border-left-color: #238636;
+}
+
+.markdown-body .markdown-alert.markdown-alert-tip .markdown-alert-title {
+  color: #3fb950;
+}
+
+.markdown-body .markdown-alert.markdown-alert-caution {
+  border-left-color: #da3633;
+}
+
+.markdown-body .markdown-alert.markdown-alert-caution .markdown-alert-title {
+  color: #f85149;
+}
+
 .fancybox__container {
 	--fancybox-zIndex: 99999999 !important;
 	--fancybox-bg: rgba(0, 0, 0, 0) !important;

--- a/www/src/utils/MarkDownConvert.ts
+++ b/www/src/utils/MarkDownConvert.ts
@@ -5,6 +5,7 @@ import { unified } from 'unified';
 import rehypeStringify from 'rehype-stringify';
 import remarkParse from 'remark-parse';
 import remarkRehype from 'remark-rehype';
+import rehypeGithubAlert from 'rehype-github-alert';
 import remarkGfm from 'remark-gfm';
 import { visit } from 'unist-util-visit';
 import rehypeSanitize from 'rehype-sanitize';
@@ -55,6 +56,7 @@ export async function MarkdownToHtml(markdown, owner, repo) {
 		.use(rehypeRaw)
 		.use(rehypeSanitize, sanitizeSchema)
 		.use(addPathToImgSrc, { owner, repo })
+		.use(rehypeGithubAlert)
 		.use(rehypeStringify, { allowDangerousHtml: true })
 		.process(markdown);
 


### PR DESCRIPTION
Uses `rehype-github-alert`, adds styles from [github-markdown-dark.css](https://github.com/sindresorhus/github-markdown-css/blob/main/github-markdown-dark.css)

![image](https://github.com/user-attachments/assets/716f767f-a753-47a7-9631-fa6c6b61a967)
