### PR TITLE
refactor: use commit id in markdown github urls

### DIFF
--- a/www/src/pages/plugin.js
+++ b/www/src/pages/plugin.js
@@ -74,7 +74,7 @@ export const getServerSideProps = async (context) => {
 			};
 		}
 
-		pluginData.readMeMarkdown = await MarkdownToHtml(pluginData?.readme, pluginData?.repoOwner, pluginData?.repoName);
+		pluginData.readMeMarkdown = await MarkdownToHtml(pluginData?.readme, pluginData?.repoOwner, pluginData?.repoName, pluginData?.commitId);
 
 		return {
 			props: { pluginData, isSteamClient, apiError: false },

--- a/www/src/pages/theme.js
+++ b/www/src/pages/theme.js
@@ -45,7 +45,7 @@ export const getServerSideProps = async (context) => {
 	const json = await res.json();
 
 	const readme = json?.read_me;
-	const markdown = await MarkdownToHtml(readme, json?.data?.github?.owner, json?.data?.github?.repo);
+	const markdown = await MarkdownToHtml(readme, json?.data?.github?.owner, json?.data?.github?.repo, json?.commit_data?.oid);
 
 	const isSteamClient = /Valve Steam Client/.test(context.req.headers['user-agent']);
 

--- a/www/src/utils/MarkDownConvert.ts
+++ b/www/src/utils/MarkDownConvert.ts
@@ -23,7 +23,7 @@ function addPathToImgSrc(options) {
 			if (node.tagName === 'img' && node.properties && node.properties.src) {
 				// Check if the src is already a full URL
 				if (!node.properties.src.startsWith('http')) {
-					node.properties.src = `https://raw.githubusercontent.com/${options.owner}/${options.repo}/HEAD/${node.properties.src}`;
+					node.properties.src = `https://raw.githubusercontent.com/${options.owner}/${options.repo}/${options.commit}/${node.properties.src}`;
 				}
 
 				if (parent) {
@@ -48,14 +48,14 @@ function addPathToImgSrc(options) {
 	};
 }
 
-export async function MarkdownToHtml(markdown, owner, repo) {
+export async function MarkdownToHtml(markdown, owner, repo, commit) {
 	const result = await unified()
 		.use(remarkParse)
 		.use(remarkGfm)
 		.use(remarkRehype, { allowDangerousHtml: true })
 		.use(rehypeRaw)
 		.use(rehypeSanitize, sanitizeSchema)
-		.use(addPathToImgSrc, { owner, repo })
+		.use(addPathToImgSrc, { owner, repo, commit })
 		.use(rehypeGithubAlert)
 		.use(rehypeStringify, { allowDangerousHtml: true })
 		.process(markdown);


### PR DESCRIPTION
Currently uses HEAD in place of the blob path part, this means images will break if they're moved in the github repo, this pr changes it to use the commit id, ensuring the images always exist.

Before:
![image](https://github.com/user-attachments/assets/cbc40c0a-4899-44d0-8de8-e8fe35dcc669)

After:
![image](https://github.com/user-attachments/assets/bee2d62b-bf1f-4f38-bec8-5806f8c757c8)
