### PR TITLE
docs: update nix package to steam-millennium

### DIFF
--- a/docs/ui/users/installing.mdx
+++ b/docs/ui/users/installing.mdx
@@ -83,7 +83,7 @@ nixpkgs.overlay = [
    if you use steam NixOS module, set millennium as steam package
 
 ```nix
-programs.steam.package = pkgs.millennium;
+programs.steam.package = pkgs.steam-millennium;
 ```
 
 if you don't, simply replace steam with millennium in packages list.


### PR DESCRIPTION
Change the package in the installing docs for nix to `steam-millenium`